### PR TITLE
Update makefile so that it builds and installs a library and the mod files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,9 @@ veryclean: clean cleandoc
 ## =======
 ## INSTALL
 ## =======
+ifeq ($(PREFIX),)
+  PREFIX := /usr/local
+endif
 
 install: $(SHARED_LIB)
 	install -d $(DESTDIR)$(PREFIX)/lib/


### PR DESCRIPTION
In order to couple with VERA, we need to build thermochimica as a library.  This modifies the makefile such that it builds libthermochimica.a using the the ar command (haven't tested on mac) then installs the library and the mod files into lib and include folders respectively.