### PR TITLE
Set DATA_DIRECTORY using thermochimica source directory instead of ENV variable

### DIFF
--- a/cmake/thermochimica_Compiler_Config.cmake
+++ b/cmake/thermochimica_Compiler_Config.cmake
@@ -5,7 +5,7 @@ SET(Fortran_FLAGS
     -fno-automatic
     -fbounds-check
     -ffpe-trap=zero
-    -D"DATA_DIRECTORY='$ENV{THERMOCHIMICA_DATA}/'"
+    -D"DATA_DIRECTORY='${${PACKAGE_NAME}_SOURCE_DIR}/data/'"
 )
 
 FOREACH(flag ${Fortran_FLAGS})


### PR DESCRIPTION
This improves the portability of the configuration