### PR TITLE
Add "lib/" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# ignore bin/ and obj/
+# ignore bin/ and obj/ and lib/
 bin/
 obj/
+lib/
 # ignore doc subdirectories except the pre-compiled manual
 doc/html/
 doc/latex/


### PR DESCRIPTION
Ignores the "lib/" directory which is created when using Thermochimica
with another program like BISON.

Closes #69