### PR TITLE
Convert API to use the C interoperability features

### DIFF
--- a/src/Thermochimica-c.c
+++ b/src/Thermochimica-c.c
@@ -4,248 +4,118 @@
 #include <map>
 #include "Thermochimica.h"
 
-void ConvertToFortran(char* fstring, std::size_t fstring_len,
-                      const char* cstring)
+void SetThermoFilename(const char *filename)
 {
-  std::size_t inlen = std::strlen(cstring);
-  std::size_t cpylen = std::min(inlen, fstring_len);
-
-  std::copy(cstring, cstring + cpylen, fstring);
-  std::fill(fstring + cpylen, fstring + fstring_len, ' ');
+  TCAPI_setThermoFilename(filename, strlen(filename));
 }
 
-void SetThermoFilename(const char* filename)
+void SetUnitTemperature(const char *unit)
 {
-  char cfilename[120];
-  int lcfilename = sizeof cfilename;
-  ConvertToFortran(cfilename,lcfilename,filename);
-  // printf("Datafile name set to %s\n",cfilename);
-
-  FORTRAN_CALL(setthermofilename)(cfilename,&lcfilename);
+  TCAPI_setUnitTemperature(unit, strlen(unit));
 }
 
-void SetUnitTemperature(const char* unit)
+void SetUnitPressure(const char *unit)
 {
-  char cunit[15];
-  int lcunit = sizeof cunit;
-  ConvertToFortran(cunit,lcunit,unit);
-  // printf("Temperature unit set to %s\n",unit);
-
-  FORTRAN_CALL(setunittemperature)(cunit);
+  TCAPI_setUnitPressure(unit, strlen(unit));
 }
 
-void SetUnitPressure(const char* unit)
+void SetUnitMass(const char *unit)
 {
-  char cunit[15];
-  int lcunit = sizeof cunit;
-  ConvertToFortran(cunit,lcunit,unit);
-
-  FORTRAN_CALL(setunitpressure)(cunit);
+  TCAPI_setUnitMass(unit, strlen(unit));
 }
 
-void SetUnitMass(const char* unit)
-{
-  char cunit[15];
-  int lcunit = sizeof cunit;
-  ConvertToFortran(cunit,lcunit,unit);
-
-  FORTRAN_CALL(setunitmass)(cunit);
-}
-
-void SetUnits(const char* tunit, const char* punit, const char* munit)
+void SetUnits(const char *tunit, const char *punit, const char *munit)
 {
   SetUnitTemperature(tunit);
   SetUnitPressure(punit);
   SetUnitMass(munit);
 }
 
-void GetOutputChemPot(char* elementName, double* chemPot, int* info)
+void GetOutputChemPot(char *elementName, double *chemPot, int *info)
 {
-  char celementName[25];
-  int lcelementName = sizeof celementName;
-  ConvertToFortran(celementName,lcelementName,elementName);
-
-  FORTRAN_CALL(getoutputchempot)(celementName, chemPot, info);
+  TCAPI_getOutputChemPot(elementName, strlen(elementName), chemPot, info);
 }
 
-void GetOutputSolnSpecies(const char* phaseName, const char* speciesName, double* moleFraction, double* chemPot, int* info)
+void GetOutputSolnSpecies(const char *phaseName, const char *speciesName, double *moleFraction, double *chemPot, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  char cspeciesName[25];
-  int lcspeciesName = sizeof cspeciesName;
-  ConvertToFortran(cspeciesName,lcspeciesName,speciesName);
-
-  FORTRAN_CALL(getoutputsolnspecies)(cphaseName, &lcphaseName, cspeciesName, &lcspeciesName, moleFraction, chemPot, info);
+  TCAPI_getOutputSolnSpecies(phaseName, strlen(phaseName), speciesName, strlen(speciesName), moleFraction, chemPot, info);
 }
 
-void GetOutputMolSpecies(const char* speciesName, double* moleFraction, double* moles, int* info)
+void GetOutputMolSpecies(const char *speciesName, double *moleFraction, double *moles, int *info)
 {
-  char cspeciesName[25];
-  int lcspeciesName = sizeof cspeciesName;
-  ConvertToFortran(cspeciesName,lcspeciesName,speciesName);
-
-  FORTRAN_CALL(getoutputmolspecies)(cspeciesName, &lcspeciesName, moleFraction, moles, info);
+  TCAPI_getOutputMolSpecies(speciesName, strlen(speciesName), moleFraction, moles, info);
 }
 
-void GetOutputMolSpeciesPhase(const char* phaseName, const char* speciesName, double* moleFraction, int* info)
+void GetOutputMolSpeciesPhase(const char *phaseName, const char *speciesName, double *moleFraction, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  char cspeciesName[25];
-  int lcspeciesName = sizeof cspeciesName;
-  ConvertToFortran(cspeciesName,lcspeciesName,speciesName);
-
-  FORTRAN_CALL(getoutputmolspeciesphase)(cphaseName, &lcphaseName, cspeciesName, &lcspeciesName, moleFraction, info);
+  TCAPI_getOutputMolSpeciesPhase(phaseName, strlen(phaseName), speciesName, strlen(speciesName), moleFraction, info);
 }
 
-void GetElementMolesInPhase(const char* elementName, const char* phaseName, double* molesElement, int* info)
+void GetElementMolesInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  char celementName[3];
-  int lcelementName = sizeof celementName;
-  ConvertToFortran(celementName,lcelementName,elementName);
-
-  FORTRAN_CALL(getelementmolesinphase)(celementName, &lcelementName, cphaseName, &lcphaseName, molesElement, info);
+  TCAPI_getElementMolesInPhase(elementName, strlen(elementName), phaseName, strlen(phaseName), molesElement, info);
 }
 
-void GetElementMoleFractionInPhase(const char* elementName, const char* phaseName, double* molesElement, int* info)
+void GetElementMoleFractionInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  char celementName[3];
-  int lcelementName = sizeof celementName;
-  ConvertToFortran(celementName,lcelementName,elementName);
-
-  FORTRAN_CALL(getelementmolefractioninphase)(celementName, &lcelementName, cphaseName, &lcphaseName, molesElement, info);
+  TCAPI_getElementMoleFractionInPhase(elementName, strlen(elementName), phaseName, strlen(phaseName), molesElement, info);
 }
 
-void GetSolnPhaseMol(const char* phaseName, double* molesPhase, int* info)
+void GetSolnPhaseMol(const char *phaseName, double *molesPhase, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getsolnphasemol)(cphaseName, molesPhase, info);
+  TCAPI_getSolnPhaseMol(phaseName, strlen(phaseName), molesPhase, info);
 }
 
-void GetPureConPhaseMol(const char* phaseName, double* molesPhase, int* info)
+void GetPureConPhaseMol(const char *phaseName, double *molesPhase, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getpureconphasemol)(cphaseName, molesPhase, info);
+  TCAPI_getPureConPhaseMol(phaseName, strlen(phaseName), molesPhase, info);
 }
 
-void GetPhaseIndex(const char* phaseName, int* index, int* info)
+void GetPhaseIndex(const char *phaseName, int *index, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getphaseindex)(cphaseName, &lcphaseName, index, info);
+  TCAPI_getPhaseIndex(phaseName, strlen(phaseName), index, info);
 }
 
-void GetOutputSiteFraction(const char* phaseName, int* sublattice, int* constituent, double* siteFraction, int* info)
+void GetOutputSiteFraction(const char *phaseName, int *sublattice, int *constituent, double *siteFraction, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getoutputsitefraction)(cphaseName, &lcphaseName, sublattice, constituent, siteFraction, info);
+  TCAPI_getOutputSiteFraction(phaseName, strlen(phaseName), sublattice, constituent, siteFraction, info);
 }
 
-void GetSublSiteMol(const char* phaseName, int* sublattice, int* constituent, double* siteMoles, int* info)
+void GetSublSiteMol(const char *phaseName, int *sublattice, int *constituent, double *siteMoles, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getsublsitemol)(cphaseName, &lcphaseName, sublattice, constituent, siteMoles, info);
+  TCAPI_getSublSiteMol(phaseName, strlen(phaseName), sublattice, constituent, siteMoles, info);
 }
 
 // MQMQA functions
 
-void GetMqmqaMolesPairs(const char* phaseName, double* molesPairs, int* info)
+void GetMqmqaMolesPairs(const char *phaseName, double *molesPairs, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  FORTRAN_CALL(getmqmqamolespairs)(cphaseName, molesPairs, info);
+  TCAPI_getMqmqaMolesPairs(phaseName, strlen(phaseName), molesPairs, info);
 }
 
-void GetMqmqaPairMolFraction(const char* phaseName, const char* pairName, double* molesPairs, int* info)
+void GetMqmqaPairMolFraction(const char *phaseName, const char *pairName, double *molesPairs, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  char cpairName[25];
-  int lcpairName = sizeof cpairName;
-  ConvertToFortran(cpairName,lcpairName,pairName);
-
-  FORTRAN_CALL(getmqmqapairmolfraction)(cphaseName, &lcphaseName, cpairName, &lcpairName, molesPairs, info);
+  TCAPI_getMqmqaPairMolFraction(phaseName, strlen(phaseName), pairName, strlen(pairName), molesPairs, info);
 }
 
-void GetMqmqaNumberPairsQuads(const char* phaseName, int* nPairs, int* nQuads, int* info)
+void GetMqmqaNumberPairsQuads(const char *phaseName, int *nPairs, int *nQuads, int *info)
 {
-  char cphaseName[25];
-  int lcphaseName = sizeof cphaseName;
-  ConvertToFortran(cphaseName,lcphaseName,phaseName);
-
-  // GetMqmqaNumberPairsQuads was given a mismatched number of arguments between Fortran and C
-  // The last argument in C is the string length.
-  FORTRAN_CALL(getmqmqanumberpairsquads)(cphaseName, nPairs, nQuads, info, &lcphaseName);
+  TCAPI_getMqmqaNumberPairsQuads(phaseName, strlen(phaseName), nPairs, nQuads, info);
 }
 
 struct cmp_str
 {
-   bool operator()(const char *a, const char *b) const
-   {
-      return std::strcmp(a, b) < 0;
-   }
+  bool operator()(const char *a, const char *b) const
+  {
+    return std::strcmp(a, b) < 0;
+  }
 };
 
 unsigned int
-atomicNumber(const char* element)
+atomicNumber(const char *element)
 {
-  static std::map<const char*, unsigned int, cmp_str> _atomic_number_map = {
-    {"H", 1}, {"He", 2}, {"Li", 3}, {"Be", 4}, {"B", 5},
-    {"C", 6}, {"N", 7}, {"O", 8}, {"F", 9}, {"Ne", 10},
-    {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15},
-    {"S", 16}, {"Cl", 17}, {"Ar", 18}, {"K", 19}, {"Ca", 20},
-    {"Sc", 21}, {"Ti", 22}, {"V", 23}, {"Cr", 24}, {"Mn", 25},
-    {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30},
-    {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35},
-    {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39}, {"Zr", 40},
-    {"Nb", 41}, {"Mo", 42}, {"Tc", 43}, {"Ru", 44}, {"Rh", 45},
-    {"Pd", 46}, {"Ag", 47}, {"Cd", 48}, {"In", 49}, {"Sn", 50},
-    {"Sb", 51}, {"Te", 52}, {"I", 53}, {"Xe", 54}, {"Cs", 55},
-    {"Ba", 56}, {"La", 57}, {"Ce", 58}, {"Pr", 59}, {"Nd", 60},
-    {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65},
-    {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70},
-    {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75},
-    {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80},
-    {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85},
-    {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90},
-    {"Pa", 91}, {"U", 92}, {"Np", 93}, {"Pu", 94}, {"Am", 95},
-    {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100},
-    {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105},
-    {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110},
-    {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115},
-    {"Lv", 116}, {"Ts", 117}, {"Og", 118}
-  };
+  static std::map<const char *, unsigned int, cmp_str> _atomic_number_map = {
+      {"H", 1}, {"He", 2}, {"Li", 3}, {"Be", 4}, {"B", 5}, {"C", 6}, {"N", 7}, {"O", 8}, {"F", 9}, {"Ne", 10}, {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15}, {"S", 16}, {"Cl", 17}, {"Ar", 18}, {"K", 19}, {"Ca", 20}, {"Sc", 21}, {"Ti", 22}, {"V", 23}, {"Cr", 24}, {"Mn", 25}, {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30}, {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35}, {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39}, {"Zr", 40}, {"Nb", 41}, {"Mo", 42}, {"Tc", 43}, {"Ru", 44}, {"Rh", 45}, {"Pd", 46}, {"Ag", 47}, {"Cd", 48}, {"In", 49}, {"Sn", 50}, {"Sb", 51}, {"Te", 52}, {"I", 53}, {"Xe", 54}, {"Cs", 55}, {"Ba", 56}, {"La", 57}, {"Ce", 58}, {"Pr", 59}, {"Nd", 60}, {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65}, {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70}, {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75}, {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80}, {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85}, {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90}, {"Pa", 91}, {"U", 92}, {"Np", 93}, {"Pu", 94}, {"Am", 95}, {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100}, {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105}, {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110}, {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115}, {"Lv", 116}, {"Ts", 117}, {"Og", 118}};
 
   auto it = _atomic_number_map.find(element);
   if (it != _atomic_number_map.end())
@@ -253,4 +123,3 @@ atomicNumber(const char* element)
   else
     return -1;
 }
-

--- a/src/Thermochimica-c.h
+++ b/src/Thermochimica-c.h
@@ -1,0 +1,34 @@
+#include <string>
+
+void SetThermoFilename(const char *);
+void SetUnitTemperature(const char *);
+void SetUnitPressure(const char *);
+void SetUnitMass(const char *);
+void SetUnits(const char *, const char *, const char *);
+
+void GetOutputChemPot(char *, double *, int *);
+void GetOutputSolnSpecies(const char *, char *, double *, double *, int *);
+void GetOutputMolSpecies(const char *, double *, double *, int *);
+void GetOutputMolSpeciesPhase(const char *, const char *, double *, int *);
+void GetElementMolesInPhase(const char *, const char *, double *, int *);
+void GetElementMoleFractionInPhase(const char *, const char *, double *, int *);
+
+void GetSolnPhaseMol(const char *, double *, int *);
+void GetPureConPhaseMol(const char *, double *, int *);
+void GetPhaseIndex(const char *, int *, int *);
+
+void GetOutputSiteFraction(const char *, int *, int *, double *, int *);
+void GetSublSiteMol(const char *, int *, int *, double *, int *);
+
+// MQMQA functions
+void GetMqmqaMolesPairs(const char *, double *, int *);
+void GetMqmqaPairMolFraction(const char *, const char *, double *, int *);
+void GetMqmqaNumberPairsQuads(const char *, int *, int *, int *);
+
+unsigned int atomicNumber(const char *);
+
+unsigned int checkTemperature(const std::string &temperature_unit);
+unsigned int checkPressure(const std::string &pressure_unit);
+unsigned int checkMass(const std::string &mass_unit);
+
+std::string elementName(unsigned int atomic_number);

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -1,0 +1,197 @@
+#include <stdio.h>
+#include <math.h>
+#include <cstring>
+#include <map>
+#include "Thermochimica.h"
+
+namespace Thermocimica
+{
+
+  void setThermoFilename(const std::string &filename)
+  {
+    TCAPI_setThermoFilename(filename.c_str(), filename.length());
+  }
+
+  void setUnitTemperature(const std::string &tunit)
+  {
+    TCAPI_setUnitTemperature(tunit.c_str(), tunit.length());
+  }
+
+  void setUnitPressure(const std::string &punit)
+  {
+    TCAPI_setUnitPressure(punit.c_str(), punit.length());
+  }
+
+  void setUnitMass(const std::string &munit)
+  {
+    TCAPI_setUnitMass(munit.c_str(), munit.length());
+  }
+
+  void setUnits(const std::string &tunit, const std::string &punit, const std::string &munit)
+  {
+    setUnitTemperature(tunit);
+    setUnitPressure(punit);
+    setUnitMass(munit);
+  }
+
+  void setStandardUnits()
+  {
+    TCAPI_setStandardUnits();
+  }
+
+  void setModelicaUnits()
+  {
+    TCAPI_setModelicaUnits();
+  }
+
+  void setTemperaturePressure(double temperature, double pressure)
+  {
+    TCAPI_setTemperaturePressure(&temperature, &pressure);
+  }
+
+  void setElementMass(int element, double mass)
+  {
+    TCAPI_setElementMass(&element, &mass);
+  }
+
+  int checkInfoThermo()
+  {
+    int idbg;
+    TCAPI_checkInfoThermo(&idbg);
+    return idbg;
+  }
+
+  void parseThermoFile()
+  {
+    TCAPI_sSParseCSDataFile();
+  }
+
+  std::pair<double, int>
+  getOutputChemPot(const std::string &elementName)
+  {
+    double chemPot;
+    int info;
+    TCAPI_getOutputChemPot(elementName.c_str(), elementName.length(), &chemPot, &info);
+    return {chemPot, info};
+  }
+
+  std::tuple<double, double, int>
+  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName)
+  {
+    double moleFrac, chemPot;
+    int info;
+    TCAPI_getOutputSolnSpecies(phaseName.c_str(), phaseName.length(), speciesName.c_str(), speciesName.length(), &moleFrac, &chemPot, &info);
+    return {moleFrac, chemPot, info};
+  }
+
+  std::tuple<double, double, int>
+  getOutputMolSpecies(const std::string &speciesName)
+  {
+    double moleFrac, moles;
+    int info;
+    TCAPI_getOutputMolSpecies(speciesName.c_str(), speciesName.length(), &moleFrac, &moles, &info);
+    return {moleFrac, moles, info};
+  }
+
+  std::pair<double, int>
+  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName)
+  {
+    double moleFrac;
+    int info;
+    TCAPI_getOutputMolSpeciesPhase(phaseName.c_str(), phaseName.length(), speciesName.c_str(), speciesName.length(), &moleFrac, &info);
+    return {moleFrac, info};
+  }
+
+  std::pair<double, int>
+  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName)
+  {
+    double molesElement;
+    int info;
+    TCAPI_getElementMolesInPhase(elementName.c_str(), elementName.length(), phaseName.c_str(), phaseName.length(), &molesElement, &info);
+    return {molesElement, info};
+  }
+
+  std::pair<double, int>
+  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName)
+  {
+    double moleFracElement;
+    int info;
+    TCAPI_getElementMoleFractionInPhase(elementName.c_str(), elementName.length(), phaseName.c_str(), phaseName.length(), &moleFracElement, &info);
+    return {moleFracElement, info};
+  }
+
+  std::pair<double, int>
+  getSolnPhaseMol(const std::string &phaseName)
+  {
+    double molesPhase;
+    int info;
+    TCAPI_getSolnPhaseMol(phaseName.c_str(), phaseName.length(), &molesPhase, &info);
+    return {molesPhase, info};
+  }
+
+  std::pair<double, int>
+  getPureConPhaseMol(const std::string &phaseName)
+  {
+    double molesPhase;
+    int info;
+    TCAPI_getPureConPhaseMol(phaseName.c_str(), phaseName.length(), &molesPhase, &info);
+    return {molesPhase, info};
+  }
+
+  std::pair<int, int>
+  getPhaseIndex(const std::string &phaseName)
+  {
+    int index, info;
+    TCAPI_getPhaseIndex(phaseName.c_str(), phaseName.length(), &index, &info);
+    return {index, info};
+  }
+
+  std::pair<double, int>
+  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent)
+  {
+    double siteFraction;
+    int info;
+    TCAPI_getOutputSiteFraction(phaseName.c_str(), phaseName.length(), &sublattice, &constituent, &siteFraction, &info);
+    return {siteFraction, info};
+  }
+
+  std::pair<double, int>
+  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent)
+  {
+    double siteMoles;
+    int info;
+    TCAPI_getSublSiteMol(phaseName.c_str(), phaseName.length(), &sublattice, &constituent, &siteMoles, &info);
+    return {siteMoles, info};
+  }
+
+  // MQMQA functions
+
+  std::pair<double, int>
+  getMqmqaMolesPairs(const std::string &phaseName)
+  {
+    double molesPairs;
+    int info;
+    TCAPI_getMqmqaMolesPairs(phaseName.c_str(), phaseName.length(), &molesPairs, &info);
+    return {molesPairs, info};
+  }
+
+  std::pair<double, int>
+  GetMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName)
+  {
+    double molesPairs;
+    int info;
+    TCAPI_getMqmqaPairMolFraction(phaseName.c_str(), phaseName.length(), pairName.c_str(), pairName.length(), &molesPairs, &info);
+    return {molesPairs, info};
+  }
+
+  std::tuple<int, int, int>
+  GetMqmqaNumberPairsQuads(const std::string &phaseName)
+  {
+    int nPairs;
+    int nQuads;
+    int info;
+    TCAPI_getMqmqaNumberPairsQuads(phaseName.c_str(), phaseName.length(), &nPairs, &nQuads, &info);
+    return {nPairs, nQuads, info};
+  }
+
+}

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -1,0 +1,52 @@
+#include <utility>
+#include <tuple>
+#include <string>
+
+#include "checkUnits.h"
+
+namespace Thermocimica
+{
+
+  void setThermoFilename(const std::string &filename);
+  void setUnitTemperature(const std::string &tunit);
+  void setUnitPressure(const std::string &punit);
+  void setUnitMass(const std::string &munit);
+  void setUnits(const std::string &tunit, const std::string &punit, const std::string &munit);
+  void setStandardUnits();
+  void setModelicaUnits();
+  void setTemperaturePressure(double temperature, double pressure);
+  void setElementMass(int element, double mass);
+  int checkInfoThermo();
+  void parseThermoFile();
+
+  std::pair<double, int>
+  getOutputChemPot(const std::string &elementName);
+  std::tuple<double, double, int>
+  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName);
+  std::tuple<double, double, int>
+  getOutputMolSpecies(const std::string &speciesName);
+  std::pair<double, int>
+  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName);
+  std::pair<double, int>
+  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int>
+  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int>
+  getSolnPhaseMol(const std::string &phaseName);
+  std::pair<double, int>
+  getPureConPhaseMol(const std::string &phaseName);
+  std::pair<int, int>
+  getPhaseIndex(const std::string &phaseName);
+  std::pair<double, int>
+  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);
+  std::pair<double, int>
+  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent);
+
+  std::pair<double, int>
+  getMqmqaMolesPairs(const std::string &phaseName);
+  std::pair<double, int>
+  GetMqmqaPairMolFraction(const char *phaseName, const char *pairName, double *molesPairs, int *info);
+  std::tuple<int, int, int>
+  GetMqmqaNumberPairsQuads(const std::string &phaseName);
+
+}

--- a/src/Thermochimica.f90
+++ b/src/Thermochimica.f90
@@ -464,7 +464,7 @@ subroutine Thermochimica
         if (INFOThermo == 0 .OR. INFOThermo == 12) call PostProcess
     end if
 
-    if (lHeatCapacityEntropyEnthalpy .AND. .NOT. lHeatCapacityCurrent) call HeatCapacity 
+    if (lHeatCapacityEntropyEnthalpy .AND. .NOT. lHeatCapacityCurrent) call HeatCapacity
 
     return
 

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -1,99 +1,67 @@
 #include <string>
-#define FORTRAN_CALL(name) name##_
+
+// Extern declarations for the bind(C) fortran TCAPI_* subroutines
 
 extern "C"
 {
-  void FORTRAN_CALL(setthermofilename)(const char *, int *);
-  void SetThermoFilename(const char *);
-  void FORTRAN_CALL(setunittemperature)(const char *);
-  void SetUnitTemperature(const char *);
-  void FORTRAN_CALL(setunitpressure)(const char *);
-  void SetUnitPressure(const char *);
-  void FORTRAN_CALL(setunitmass)(const char *);
-  void SetUnitMass(const char *);
-  void FORTRAN_CALL(setunits)(const char *, const char *, const char *);
-  void SetUnits(const char *, const char *, const char *);
-  void FORTRAN_CALL(setstandardunits)();
+  void TCAPI_setThermoFilename(const char *, std::size_t);
+  void TCAPI_setUnitTemperature(const char *, std::size_t);
+  void TCAPI_setUnitPressure(const char *, std::size_t);
+  void TCAPI_setUnitMass(const char *, std::size_t);
+  void TCAPI_setStandardUnits();
+  void TCAPI_setModelicaUnits();
 
-  void FORTRAN_CALL(getmolfraction)(int *, double *, int *);
-  void FORTRAN_CALL(getchemicalpotential)(int *, double *, int *);
-  void FORTRAN_CALL(getelementpotential)(int *, double *, int *);
+  void TCAPI_getMolFraction(int *, double *, int *);
+  void TCAPI_getChemicalPotential(int *, double *, int *);
+  void TCAPI_getElementPotential(int *, double *, int *);
 
-  void FORTRAN_CALL(getoutputchempot)(char *, double *, int *);
-  void GetOutputChemPot(char *, double *, int *);
-  void FORTRAN_CALL(getoutputsolnspecies)(const char *, int *, const char *, int *, double *, double *, int *);
-  void GetOutputSolnSpecies(const char *, char *, double *, double *, int *);
-  void FORTRAN_CALL(getoutputmolspecies)(const char *, int *, double *, double *, int *);
-  void GetOutputMolSpecies(const char *, double *, double *, int *);
-  void FORTRAN_CALL(getoutputmolspeciesphase)(const char *, int *, const char *, int *, double *, int *);
-  void GetOutputMolSpeciesPhase(const char *, const char *, double *, int *);
-  void FORTRAN_CALL(getelementmolesinphase)(const char *, int *, const char *, int *, double *, int *);
-  void GetElementMolesInPhase(const char *, const char *, double *, int *);
-  void FORTRAN_CALL(getelementmolefractioninphase)(const char *, int *, const char *, int *, double *, int *);
-  void GetElementMoleFractionInPhase(const char *, const char *, double *, int *);
+  void TCAPI_getOutputChemPot(const char *, std::size_t, double *, int *);
+  void TCAPI_getOutputSolnSpecies(const char *, std::size_t, const char *, std::size_t, double *, double *, int *);
+  void TCAPI_getOutputMolSpecies(const char *, std::size_t, double *, double *, int *);
+  void TCAPI_getOutputMolSpeciesPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getElementMolesInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getElementMoleFractionInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
 
-  void FORTRAN_CALL(getsolnphasemol)(const char *, double *, int *);
-  void GetSolnPhaseMol(const char *, double *, int *);
-  void FORTRAN_CALL(getpureconphasemol)(const char *, double *, int *);
-  void GetPureConPhaseMol(const char *, double *, int *);
-  void FORTRAN_CALL(getphaseindex)(const char *, int *, int *, int *);
-  void GetPhaseIndex(const char *, int *, int *);
+  void TCAPI_getSolnPhaseMol(const char *, std::size_t, double *, int *);
+  void TCAPI_getPureConPhaseMol(const char *, std::size_t, double *, int *);
+  void TCAPI_getPhaseIndex(const char *, std::size_t, int *, int *);
 
-  void FORTRAN_CALL(getoutputsitefraction)(const char *, int *, int *, int *, double *, int *);
-  void GetOutputSiteFraction(const char *, int *, int *, double *, int *);
-  void FORTRAN_CALL(getsublsitemol)(const char *, int *, int *, int *, double *, int *);
-  void GetSublSiteMol(const char *, int *, int *, double *, int *);
+  void TCAPI_getOutputSiteFraction(const char *, std::size_t, int *, int *, double *, int *);
+  void TCAPI_getSublSiteMol(const char *, std::size_t, int *, int *, double *, int *);
 
-  void FORTRAN_CALL(setprintresultsmode)(int *);
+  void TCAPI_setPrintResultsMode(int *);
 
-  void FORTRAN_CALL(setelementmass)(int *, double *);
-  void FORTRAN_CALL(presetelementmass)(int *, double *);
-  void FORTRAN_CALL(settemperaturepressure)(double *, double *);
-  void FORTRAN_CALL(checkinfothermo)(int *);
+  void TCAPI_setElementMass(int *, double *);
+  void TCAPI_presetElementMass(int *, double *);
+  void TCAPI_setTemperaturePressure(double *, double *);
+  void TCAPI_checkInfoThermo(int *);
 
+  void TCAPI_sSParseCSDataFile();
+  void TCAPI_thermochimica();
 
-  void FORTRAN_CALL(ssparsecsdatafile)();
-  void FORTRAN_CALL(thermochimica)();
+  void TCAPI_solPhaseParse(int *, double *);
 
-  void FORTRAN_CALL(solphaseparse)(int *, double *);
+  void TCAPI_thermoDebug();
 
-  void FORTRAN_CALL(thermodebug)();
+  void TCAPI_printResults();
+  void TCAPI_printState();
 
-  void FORTRAN_CALL(printresults)();
-  void FORTRAN_CALL(printstate)();
-
-  void FORTRAN_CALL(resetinfothermo)();
-  void FORTRAN_CALL(resetthermo)();
-  void FORTRAN_CALL(resetthermoall)();
+  void TCAPI_resetInfoThermo();
+  void TCAPI_resetThermo();
+  void TCAPI_resetThermoAll();
 
   // re-initialization-related functions
-  void FORTRAN_CALL(savereinitdata)();
-  void FORTRAN_CALL(getreinitdatasizes)(int *, int *);
-  void FORTRAN_CALL(getmolesphase)(double *);
-  void FORTRAN_CALL(getassemblage)(int *);
-  void FORTRAN_CALL(setreinitrequested)(int *);
-  void FORTRAN_CALL(resetreinit)();
-  void FORTRAN_CALL(getallelementpotential)(double *);
-  void FORTRAN_CALL(getelementfraction)(int *, double *);
+  void TCAPI_saveReinitData();
+  void TCAPI_getReinitDataSizes(int *, int *);
+  void TCAPI_getMolesPhase(double *);
+  void TCAPI_getAssemblage(int *);
+  void TCAPI_setReinitRequested(int *);
+  void TCAPI_resetReinit();
+  void TCAPI_getAllElementPotential(double *);
+  void TCAPI_getElementFraction(int *, double *);
 
   // MQMQA functions
-  void FORTRAN_CALL(getmqmqamolespairs)(const char *, double *, int *);
-  void GetMqmqaMolesPairs(const char *, double *, int *);
-  void FORTRAN_CALL(getmqmqapairmolfraction)(const char *, int *, const char *, int *, double *, int *);
-  void GetMqmqaPairMolFraction(const char *, const char *, double *, int *);
-  // GetMqmqaNumberPairsQuads was given a mismatched number of arguments between Fortran and C
-  // The last argument in C is the string length.
-  void FORTRAN_CALL(getmqmqanumberpairsquads)(const char *, int *, int *, int *, int *);
-  void GetMqmqaNumberPairsQuads(const char *, int *, int *, int *);
-
-
-  unsigned int atomicNumber(const char *);
+  void TCAPI_getMqmqaMolesPairs(const char *, std::size_t, double *, int *);
+  void TCAPI_getMqmqaPairMolFraction(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getMqmqaNumberPairsQuads(const char *, std::size_t, int *, int *, int *);
 }
-
-void ConvertToFortran(char *, std::size_t, const char *);
-
-unsigned int checkTemperature(const std::string & temperature_unit);
-unsigned int checkPressure(const std::string & pressure_unit);
-unsigned int checkMass(const std::string & mass_unit);
-
-std::string elementName(unsigned int atomic_number);

--- a/src/debug/PrintState.f90
+++ b/src/debug/PrintState.f90
@@ -1,18 +1,19 @@
-subroutine PrintState
+subroutine PrintState() &
+   bind(C, name="TCAPI_printState")
 
-    USE ModuleThermo
-    USE ModuleThermoIO
-    USE ModuleGEMSolver
+   USE ModuleThermo
+   USE ModuleThermoIO
+   USE ModuleGEMSolver
 
-    implicit none
+   implicit none
 
-    integer :: i
+   integer :: i
 
-    print *, "Temperature: ", dTemperature, " Pressure: ", dPressure
+   print *, "Temperature: ", dTemperature, " Pressure: ", dPressure
 
-    print *, "Element Masses:"
-    do i = 1, nElements
+   print *, "Element Masses:"
+   do i = 1, nElements
       print *, iElementSystem(i), " ", dMolesElement(i)
-    end do
+   end do
 
 end subroutine PrintState

--- a/src/postprocess/CouplingUtilities.f90
+++ b/src/postprocess/CouplingUtilities.f90
@@ -1,289 +1,360 @@
 subroutine SetThermoFileName(cFileName, lcFileName) &
-  bind(C, name="setThermoFileName")
+    bind(C, name="TCAPI_setThermoFilename")
 
-  USE ModuleThermoIO, ONLY: cThermoFileName
-  USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: cThermoFileName
+    USE,INTRINSIC :: ISO_C_BINDING
 
-  implicit none
+    implicit none
 
-  character(kind=c_char,len=1), target, intent(in) :: cFileName(*)
-  integer(c_size_t), intent(in), value             :: lcFileName
-  character(kind=c_char,len=lcFileName), pointer :: fFileName
+    character(kind=c_char,len=1), target, intent(in) :: cFileName(*)
+    integer(c_size_t), intent(in), value             :: lcFileName
+    character(kind=c_char,len=lcFileName), pointer :: fFileName
 
-  call c_f_pointer(cptr=c_loc(cFileName), fptr=fFileName)
-  cThermoFileName       = fFileName
+    call c_f_pointer(cptr=c_loc(cFileName), fptr=fFileName)
+    cThermoFileName       = fFileName
 
-  return
+    return
 
 end subroutine SetThermoFileName
 
 subroutine SetThermoFileNameFortran(cFileName)
 
-  USE ModuleThermoIO, ONLY: cThermoFileName
+    USE ModuleThermoIO, ONLY: cThermoFileName
 
-  implicit none
+    implicit none
 
-  character(*), intent(in)::  cFileName
+    character(*), intent(in)::  cFileName
 
-  cThermoFileName       = cFileName
+    cThermoFileName       = cFileName
 
-  return
+    return
 
 end subroutine SetThermoFileNameFortran
 
 subroutine SetUnitTemperature(cUnitTemperature, lcUnitTemperature) &
-  bind(C, name="setUnitTemperature")
+    bind(C, name="TCAPI_setUnitTemperature")
 
-  USE ModuleThermoIO, ONLY: cInputUnitTemperature
-  USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: cInputUnitTemperature
+    USE,INTRINSIC :: ISO_C_BINDING
 
-  implicit none
+    implicit none
 
-  character(kind=c_char,len=1), target, intent(in)      :: cUnitTemperature(*)
-  integer(c_size_t), intent(in), value                  :: lcUnitTemperature
-  character(kind=c_char,len=lcUnitTemperature), pointer :: fUnitTemperature
+    character(kind=c_char,len=1), target, intent(in)      :: cUnitTemperature(*)
+    integer(c_size_t), intent(in), value                  :: lcUnitTemperature
+    character(kind=c_char,len=lcUnitTemperature), pointer :: fUnitTemperature
 
-  call c_f_pointer(cptr=c_loc(cUnitTemperature), fptr=fUnitTemperature)
-  cInputUnitTemperature = fUnitTemperature
+    call c_f_pointer(cptr=c_loc(cUnitTemperature), fptr=fUnitTemperature)
+    cInputUnitTemperature = fUnitTemperature
 
-  return
+    return
 
 end subroutine SetUnitTemperature
 
 subroutine SetUnitPressure(cUnitPressure, lcUnitPressure) &
-  bind(C, name="setUnitPressure")
+    bind(C, name="TCAPI_setUnitPressure")
 
-  USE ModuleThermoIO, ONLY: cInputUnitPressure
-  USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: cInputUnitPressure
+    USE,INTRINSIC :: ISO_C_BINDING
 
-  implicit none
+    implicit none
 
-  character(kind=c_char,len=1), target, intent(in)   :: cUnitPressure(*)
-  integer(c_size_t), intent(in), value               :: lcUnitPressure
-  character(kind=c_char,len=lcUnitPressure), pointer :: fUnitPressure
+    character(kind=c_char,len=1), target, intent(in)   :: cUnitPressure(*)
+    integer(c_size_t), intent(in), value               :: lcUnitPressure
+    character(kind=c_char,len=lcUnitPressure), pointer :: fUnitPressure
 
-  call c_f_pointer(cptr=c_loc(cUnitPressure), fptr=fUnitPressure)
-  cInputUnitPressure = fUnitPressure
+    call c_f_pointer(cptr=c_loc(cUnitPressure), fptr=fUnitPressure)
+    cInputUnitPressure = fUnitPressure
 
-  return
+    return
 
 end subroutine SetUnitPressure
 
 subroutine SetUnitMass(cUnitMass, lcUnitMass) &
-  bind(C, name="setUnitMass")
+    bind(C, name="TCAPI_setUnitMass")
 
-  USE ModuleThermoIO, ONLY: cInputUnitMass
-  USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: cInputUnitMass
+    USE,INTRINSIC :: ISO_C_BINDING
 
-  implicit none
+    implicit none
 
-  character(kind=c_char,len=1), target, intent(in)   :: cUnitMass(*)
-  integer(c_size_t), intent(in), value               :: lcUnitMass
-  character(kind=c_char,len=lcUnitMass), pointer :: fUnitMass
+    character(kind=c_char,len=1), target, intent(in)   :: cUnitMass(*)
+    integer(c_size_t), intent(in), value               :: lcUnitMass
+    character(kind=c_char,len=lcUnitMass), pointer :: fUnitMass
 
-  call c_f_pointer(cptr=c_loc(cUnitMass), fptr=fUnitMass)
-  cInputUnitMass = fUnitMass
+    call c_f_pointer(cptr=c_loc(cUnitMass), fptr=fUnitMass)
+    cInputUnitMass = fUnitMass
 
-  return
+    return
 
 end subroutine SetUnitMass
 
 subroutine SetStandardUnits() &
-  bind(C, name="setStandardUnits")
+    bind(C, name="TCAPI_setStandardUnits")
 
-  USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
+    USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
 
-  implicit none
+    implicit none
 
-  cInputUnitTemperature = 'K'
-  cInputUnitPressure    = 'atm'
-  cInputUnitMass        = 'moles'
+    cInputUnitTemperature = 'K'
+    cInputUnitPressure    = 'atm'
+    cInputUnitMass        = 'moles'
 
-  return
+    return
 
 end subroutine SetStandardUnits
 
 subroutine SetModelicaUnits() &
-  bind(C, name="setModelicaUnits")
+    bind(C, name="TCAPI_setModelicaUnits")
 
-  USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
+    USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
 
-  implicit none
+    implicit none
 
-  cInputUnitTemperature = 'K'
-  cInputUnitPressure    = 'Pa'
-  cInputUnitMass        = 'moles'
+    cInputUnitTemperature = 'K'
+    cInputUnitPressure    = 'Pa'
+    cInputUnitMass        = 'moles'
 
-  return
+    return
 
 end subroutine SetModelicaUnits
 
 subroutine SetUnits(cTemperature, cPressure, cMass)
 
-  USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
+    USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
 
-  implicit none
+    implicit none
 
-  character(*), intent(in)::  cTemperature
-  character(*), intent(in)::  cPressure
-  character(*), intent(in)::  cMass
+    character(*), intent(in)::  cTemperature
+    character(*), intent(in)::  cPressure
+    character(*), intent(in)::  cMass
 
-  character(15) :: cTemperatureLen
-  character(15) :: cPressureLen
-  character(15) :: cMassLen
+    character(15) :: cTemperatureLen
+    character(15) :: cPressureLen
+    character(15) :: cMassLen
 
-  cInputUnitTemperature = 'K'
-  cInputUnitPressure    = 'atm'
-  cInputUnitMass        = 'moles'
+    cInputUnitTemperature = 'K'
+    cInputUnitPressure    = 'atm'
+    cInputUnitMass        = 'moles'
 
 
-  if(len_trim(cTemperature) > 0)then
-     cTemperatureLen = cTemperature(1:min(15,len(cTemperature)))
-     cInputUnitTemperature = trim(cTemperatureLen)
-  end if
-  if(len_trim(cPressure) > 0)then
-     cPressureLen = cPressure(1:min(15,len(cPressure)))
-     cInputUnitPressure = trim(cPressureLen)
-  end if
-  if(len_trim(cMass) > 0)then
-     cMassLen = cMass(1:min(15,len(cMass)))
-     cInputUnitMass = trim(cMassLen)
-  end if
+    if(len_trim(cTemperature) > 0)then
+        cTemperatureLen = cTemperature(1:min(15,len(cTemperature)))
+        cInputUnitTemperature = trim(cTemperatureLen)
+    end if
+    if(len_trim(cPressure) > 0)then
+        cPressureLen = cPressure(1:min(15,len(cPressure)))
+        cInputUnitPressure = trim(cPressureLen)
+    end if
+    if(len_trim(cMass) > 0)then
+        cMassLen = cMass(1:min(15,len(cMass)))
+        cInputUnitMass = trim(cMassLen)
+    end if
 
-  return
+    return
 
 end subroutine SetUnits
 
 subroutine SetTemperaturePressure(dTemp, dPress) &
-  bind(C, name="setTemperaturePressure")
+    bind(C, name="TCAPI_setTemperaturePressure")
 
-  USE ModuleThermoIO, ONLY: dTemperature, dPressure
+    USE ModuleThermoIO, ONLY: dTemperature, dPressure
 
-  implicit none
+    implicit none
 
-  real(8), intent(in)::  dTemp
-  real(8), intent(in)::  dPress
+    real(8), intent(in)::  dTemp
+    real(8), intent(in)::  dPress
 
-  dTemperature = dTemp
-  dPressure = dPress
+    dTemperature = dTemp
+    dPressure = dPress
 
-  return
+    return
 
 end subroutine SetTemperaturePressure
 
-subroutine SetPrintResultsMode(Pinfo)
+subroutine SetPrintResultsMode(Pinfo) &
+    bind(C, name="TCAPI_setPrintResultsMode")
 
-  USE ModuleThermoIO, ONLY: iPrintResultsMode
+    USE ModuleThermoIO, ONLY: iPrintResultsMode
 
-  implicit none
+    implicit none
 
-  integer Pinfo
+    integer Pinfo
 
-  iPrintResultsMode = Pinfo
+    iPrintResultsMode = Pinfo
 
-  return
+    return
 
 end subroutine SetPrintResultsMode
 
-subroutine PresetElementMass(iAtom, dMass)
+subroutine PresetElementMass(iAtom, dMass) &
+    bind(C, name="TCAPI_presetElementMass")
 
-  USE ModuleThermoIO, ONLY: dElementMass, lPreset
+    USE ModuleThermoIO, ONLY: dElementMass, lPreset
 
-  implicit none
+    implicit none
 
-  integer, intent(in)::  iAtom
-  real(8), intent(in)::  dMass
+    integer, intent(in)::  iAtom
+    real(8), intent(in)::  dMass
 
-  if( iAtom == 0 )then
-      dElementMass = dMass
-  else if( iAtom < 0 .or. iAtom > 118 )then
-      write(*,*) 'Error in PresetElementMass ', iAtom, dMass
-      stop
-  else
-      dElementMass(iAtom)      = dMass
-      lPreset(iAtom)           = .TRUE.
-  end if
+    if( iAtom == 0 )then
+        dElementMass = dMass
+    else if( iAtom < 0 .or. iAtom > 118 )then
+        write(*,*) 'Error in PresetElementMass ', iAtom, dMass
+        stop
+    else
+        dElementMass(iAtom)      = dMass
+        lPreset(iAtom)           = .TRUE.
+    end if
 
-  return
+    return
 
 end subroutine PresetElementMass
 
 subroutine SetElementMass(iAtom, dMass) &
-  bind(C, name="setElementMass")
+    bind(C, name="TCAPI_setElementMass")
 
 
-  USE ModuleThermoIO, ONLY: dElementMass, lPreset
+    USE ModuleThermoIO, ONLY: dElementMass, lPreset
 
-  implicit none
+    implicit none
 
-  integer, intent(in)::  iAtom
-  real(8), intent(in)::  dMass
-  integer :: i
+    integer, intent(in)::  iAtom
+    real(8), intent(in)::  dMass
+    integer :: i
 
-  if( iAtom == 0 ) then
-      do i = 0, 118
-          if (.NOT. lPreset(i)) dElementMass(i) = dMass
-      end do
-  else if( iAtom < 0 .or. iAtom > 118 )then
-      write(*,*) 'Error in SetElementMass ', iAtom, dMass
-      stop
-  else
-      if (.NOT. lPreset(iAtom)) dElementMass(iAtom) = dMass
-  end if
+    if( iAtom == 0 ) then
+        do i = 0, 118
+            if (.NOT. lPreset(i)) dElementMass(i) = dMass
+        end do
+    else if( iAtom < 0 .or. iAtom > 118 )then
+        write(*,*) 'Error in SetElementMass ', iAtom, dMass
+        stop
+    else
+        if (.NOT. lPreset(iAtom)) dElementMass(iAtom) = dMass
+    end if
 
-  return
+    return
 
 end subroutine SetElementMass
 
 subroutine GetElementMass(iAtom, dMass)
 
-  USE ModuleThermoIO, ONLY: dElementMass
+    USE ModuleThermoIO, ONLY: dElementMass
 
-  implicit none
+    implicit none
 
-  integer, intent(in)::  iAtom
-  real(8), intent(out)::  dMass
+    integer, intent(in)::  iAtom
+    real(8), intent(out)::  dMass
 
-  dMass = 0D0
-  if (iAtom > 0 .AND. iAtom <= 118) then
-      dMass =  dElementMass(iAtom)
-  end if
+    dMass = 0D0
+    if (iAtom > 0 .AND. iAtom <= 118) then
+        dMass =  dElementMass(iAtom)
+    end if
 
-  return
+    return
 
 end subroutine GetElementMass
 
 subroutine CheckINFOThermo(dbginfo) &
-  bind(C, name="checkInfoThermo")
+    bind(C, name="TCAPI_checkInfoThermo")
 
-  USE ModuleThermoIO, ONLY: INFOThermo
+    USE ModuleThermoIO, ONLY: INFOThermo
 
-  implicit none
+    implicit none
 
-  integer, intent(out)::  dbginfo
+    integer, intent(out)::  dbginfo
 
-  dbginfo = INFOThermo
+    dbginfo = INFOThermo
 
-  return
+    return
 
 end subroutine CheckINFOThermo
 
-subroutine ResetINFOThermo
+subroutine ResetINFOThermo() &
+    bind(C, name="TCAPI_resetInfoThermo")
 
-  USE ModuleThermoIO, ONLY: INFOThermo
+    USE ModuleThermoIO, ONLY: INFOThermo
 
-  implicit none
+    implicit none
 
-  INFOThermo=0
+    INFOThermo=0
 
-  return
+    return
 
 end subroutine ResetINFOThermo
 
-subroutine SolPhaseParse(iElem, dMolSum)
+subroutine ResetThermoAPI() &
+    bind(C, name="TCAPI_resetThermo")
 
-  ! quick hack for bison, ZrH, H in
-  ! needs checking of input, intents, etc
+    implicit none
+
+    call ResetThermo
+
+    return
+
+end subroutine ResetThermoAPI
+
+subroutine ResetThermoAllAPI() &
+    bind(C, name="TCAPI_resetThermoAll")
+
+    implicit none
+
+    call ResetThermoAll
+
+    return
+
+end subroutine ResetThermoAllAPI
+
+subroutine ThermoDebugAPI() &
+    bind(C, name="TCAPI_thermoDebug")
+
+    implicit none
+
+    call ThermoDebug
+
+    return
+
+end subroutine ThermoDebugAPI
+
+subroutine PrintResultsAPI() &
+    bind(C, name="TCAPI_printResults")
+
+    implicit none
+
+    call PrintResults
+
+    return
+
+end subroutine PrintResultsAPI
+
+subroutine SaveReinitDataAPI() &
+    bind(C, name="TCAPI_saveReinitData")
+
+    implicit none
+
+    call SaveReinitData
+
+    return
+
+end subroutine SaveReinitDataAPI
+
+subroutine ResetReinitAPI() &
+    bind(C, name="TCAPI_resetReinit")
+
+    implicit none
+
+    call ResetReinit
+
+    return
+
+end subroutine ResetReinitAPI
+
+
+subroutine SolPhaseParse(iElem, dMolSum) &
+    bind(C, name="TCAPI_solPhaseParse")
+
+    ! quick hack for bison, ZrH, H in
+    ! needs checking of input, intents, etc
 
     USE ModuleThermoIO
     USE ModuleThermo
@@ -304,19 +375,19 @@ subroutine SolPhaseParse(iElem, dMolSum)
     allocate(dTempVec(nSolnPhases))
 
     do i = 1, nSolnPhases
-       j = nElements - i + 1
-       dTempVec(i) = dMolesPhase(j)
+        j = nElements - i + 1
+        dTempVec(i) = dMolesPhase(j)
     end do
 
     dMolSum = 0D0
     do j = 1, nSolnPhases
 
-       ! Absolute solution phase index:
-       k = -iAssemblage(nElements - j + 1)
+        ! Absolute solution phase index:
+        k = -iAssemblage(nElements - j + 1)
 
-       dMolTemp=dTempVec(j) * dEffStoichSolnPhase(k,iElem)
-       dMolSum = dMolSum + dMolTemp
-      !  write(*,"(A,A,e13.6)", ADVANCE="NO") ' -- ', trim(cSolnPhaseName(k)), dMolTemp
+        dMolTemp=dTempVec(j) * dEffStoichSolnPhase(k,iElem)
+        dMolSum = dMolSum + dMolTemp
+        !  write(*,"(A,A,e13.6)", ADVANCE="NO") ' -- ', trim(cSolnPhaseName(k)), dMolTemp
     end do
     ! write(*,*)
 
@@ -324,7 +395,7 @@ subroutine SolPhaseParse(iElem, dMolSum)
 end subroutine SolPhaseParse
 
 subroutine SSParseCSDataFile() &
-    bind(C, name="sSParseCSDataFile")
+    bind(C, name="TCAPI_sSParseCSDataFile")
 
     USE ModuleThermoIO
     USE ModuleSS
@@ -337,348 +408,370 @@ subroutine SSParseCSDataFile() &
 
 end subroutine SSParseCSDataFile
 
+subroutine ThermochimicaAPI() &
+    bind(C, name="TCAPI_thermochimica")
+
+    implicit none
+
+    call Thermochimica()
+
+    return
+
+end subroutine ThermochimicaAPI
+
 subroutine APpmInBToMolInVol(dAppm, dAMassPerMol, dBMassPerMol, dBDens, dVol, iMolScale, dAMol, dBMol)
 
-  ! Input
-  ! dAppm          = element A, ppm, 0.000001 MU/MU
-  ! dAMassPerMol   = element A, MU / mol
-  ! dBMassPerMol   = element B, MU / mol
-  ! dBDens         = element B, Density, Mass unit per unit volume  MU/LU^3
-  ! dVol           = Volume, LU^3
-  ! iMolScale      = Scale mol values wrt to 1, 2, or total
-  ! Output
-  ! dAMol          = Mol of element A in dVol
-  ! dBMol          = Mol of element B in dVol
+    ! Input
+    ! dAppm          = element A, ppm, 0.000001 MU/MU
+    ! dAMassPerMol   = element A, MU / mol
+    ! dBMassPerMol   = element B, MU / mol
+    ! dBDens         = element B, Density, Mass unit per unit volume  MU/LU^3
+    ! dVol           = Volume, LU^3
+    ! iMolScale      = Scale mol values wrt to 1, 2, or total
+    ! Output
+    ! dAMol          = Mol of element A in dVol
+    ! dBMol          = Mol of element B in dVol
 
-  implicit none
+    implicit none
 
-  integer, intent(in)  :: iMolScale
-  real(8), intent(in)  :: dAppm, dAMassPerMol, dBMassPerMol, dBDens, dVol
-  real(8), intent(out) :: dAMol, dBMol
-  real(8)              :: dATotalMass, dBTotalMass
+    integer, intent(in)  :: iMolScale
+    real(8), intent(in)  :: dAppm, dAMassPerMol, dBMassPerMol, dBDens, dVol
+    real(8), intent(out) :: dAMol, dBMol
+    real(8)              :: dATotalMass, dBTotalMass
 
-  ! ppm is 0.000001 MU/MU
-  ! assume total density is equal to density of solvent
-  dBTotalMass = dBDens * dVol
-  dATotalMass = dBTotalMass * 0.000001 * dAppm
+    ! ppm is 0.000001 MU/MU
+    ! assume total density is equal to density of solvent
+    dBTotalMass = dBDens * dVol
+    dATotalMass = dBTotalMass * 0.000001 * dAppm
 
-  dAMol = dATotalMass / dAMassPerMol
-  dBMol = dBTotalMass / dBMassPerMol
+    dAMol = dATotalMass / dAMassPerMol
+    dBMol = dBTotalMass / dBMassPerMol
 
-  if( iMolScale == 1 )then
-     dBMol = dBMol / dAMol
-     dAmol = 1D0
-  else if( iMolScale == 2 )then
-     dAMol = dAMol / dBMol
-     dBmol = 1D0
-  else if( iMolScale == 3 )then
-     dAMol = dAMol / (dAMol+dBMol)
-     dBmol = 1D0 - dAMol
-  end if
+    if( iMolScale == 1 )then
+        dBMol = dBMol / dAMol
+        dAmol = 1D0
+    else if( iMolScale == 2 )then
+        dAMol = dAMol / dBMol
+        dBmol = 1D0
+    else if( iMolScale == 3 )then
+        dAMol = dAMol / (dAMol+dBMol)
+        dBmol = 1D0 - dAMol
+    end if
 
-  return
+    return
 
 end subroutine APpmInBToMolInVol
 
 subroutine SSInitiateZRHD
 
-  call SetThermoFileNameFortran('ZRHD_MHP.dat')
-  call SetUnits('K','atm','moles')
+    call SetThermoFileNameFortran('ZRHD_MHP.dat')
+    call SetUnits('K','atm','moles')
 
-  return
+    return
 
 end subroutine SSInitiateZRHD
 
 subroutine SSInitiateUO2PX
 
-  call SetThermoFileNameFortran('DBV6_TMB_modified.dat')
-  call SetUnits('K','atm','moles')
+    call SetThermoFileNameFortran('DBV6_TMB_modified.dat')
+    call SetUnits('K','atm','moles')
 
-  return
+    return
 
 end subroutine SSInitiateUO2PX
 
 subroutine tokenize(str, delim, word, lword, n)
 
-  implicit none
+    implicit none
 
-  character (len=*) :: str
-  character(1)      :: delim
-  integer           :: lword
-  character(lword)  :: word(*)     ! need to fix the maximum n
-  integer           :: n
+    character (len=*) :: str
+    character(1)      :: delim
+    integer           :: lword
+    character(lword)  :: word(*)     ! need to fix the maximum n
+    integer           :: n
 
-  integer :: pos1, pos2, i
+    integer :: pos1, pos2, i
 
-  n = 0
-  pos1 = 1
-  pos2 = 0
+    n = 0
+    pos1 = 1
+    pos2 = 0
 
-  DO
-     pos2 = INDEX(str(pos1:), delim)
-     IF (pos2 == 0) THEN
+    DO
+        pos2 = INDEX(str(pos1:), delim)
+        IF (pos2 == 0) THEN
+            n = n + 1
+            word(n)=''
+            word(n) = str(pos1:)
+            EXIT
+        END IF
         n = n + 1
         word(n)=''
-        word(n) = str(pos1:)
-        EXIT
-     END IF
-     n = n + 1
-     word(n)=''
-     word(n) = str(pos1:pos1+pos2-2)
-     pos1 = pos2+pos1
-  END DO
+        word(n) = str(pos1:pos1+pos2-2)
+        pos1 = pos2+pos1
+    END DO
 
-  ! write(*,"(3A)") ' tokenize ', str,';'
-  DO i = 1, n
-      ! WRITE(*,"(2A)", ADVANCE="NO") word(i), "."
-  END DO
-  ! write(*,*)
+    ! write(*,"(3A)") ' tokenize ', str,';'
+    DO i = 1, n
+        ! WRITE(*,"(2A)", ADVANCE="NO") word(i), "."
+    END DO
+    ! write(*,*)
 
 end subroutine tokenize
 
 subroutine chomp(str, len)
-  ! remove \0 from c string
-  ! must pass len that was result from strlen
-  implicit none
+    ! remove \0 from c string
+    ! must pass len that was result from strlen
+    implicit none
 
-  character (len=*) ::  str
-  ! character(1)      :: str(*)
-  integer           :: len,lchop
+    character (len=*) ::  str
+    ! character(1)      :: str(*)
+    integer           :: len,lchop
 
-  ! write(*,*) 'chomp ',str,' len ',len
+    ! write(*,*) 'chomp ',str,' len ',len
 
-  lchop=len+1
-  str(lchop:lchop)=""
-  ! str=trim(str)
+    lchop=len+1
+    str(lchop:lchop)=""
+    ! str=trim(str)
 
-  return
+    return
 end subroutine chomp
 
 subroutine matchdict( word, dictionary, nwords, lenword, imatch )
-  !
-  !    Match word in a dictionary
-  !    nwords - number of words in dictionary
-  !    lenwords - array holding length of the words
-  !    imatch - 0 = no match, 1 = match
+    !
+    !    Match word in a dictionary
+    !    nwords - number of words in dictionary
+    !    lenwords - array holding length of the words
+    !    imatch - 0 = no match, 1 = match
 
-  implicit none
+    implicit none
 
-  character (len=*) ::  word
-  integer           :: nwords, lenword
-  character (len=lenword) :: dictionary(nwords)
-  character(25) :: cWord
+    character (len=*) ::  word
+    integer           :: nwords, lenword
+    character (len=lenword) :: dictionary(nwords)
+    character(25) :: cWord
 
-  integer :: imatch
+    integer :: imatch
 
-  integer :: i,lword
+    integer :: i,lword
 
-  imatch=0
+    imatch=0
 
-  ! write(*,*) 'matchdict ',word
+    ! write(*,*) 'matchdict ',word
 
-  lword=len(word)
-  ! write(*,*) 'word ',word,'lword ', lword
-  if(lword > 25)then
-     write(*,"(A,i5)") "matchdict: word to match is too big ", lword
-     stop
-  end if
+    lword=len(word)
+    ! write(*,*) 'word ',word,'lword ', lword
+    if(lword > 25)then
+        write(*,"(A,i5)") "matchdict: word to match is too big ", lword
+        stop
+    end if
 
-  cWord=""
-  cWord(1:lword)=word(1:lword)
+    cWord=""
+    cWord(1:lword)=word(1:lword)
 
-  do i=1,nwords
-     if ( cWord == dictionary(i) ) then
-        imatch = imatch + 1
-     end if
-  end do
+    do i=1,nwords
+        if ( cWord == dictionary(i) ) then
+            imatch = imatch + 1
+        end if
+    end do
 
-  return
+    return
 end subroutine matchdict
 
 subroutine chopnull(str)
 
-  implicit none
+    implicit none
 
-  !
-  character (len=*) ::  str
-  integer           ::  iloc
+    !
+    character (len=*) ::  str
+    integer           ::  iloc
 
-  iloc=scan(str,char(0))
+    iloc=scan(str,char(0))
 
-  if(iloc > 0)then
-     str(iloc:iloc)=""
-  end if
+    if(iloc > 0)then
+        str(iloc:iloc)=""
+    end if
 
-  return
+    return
 end subroutine chopnull
 
-subroutine getMolFraction(i, value, ierr)
-  USE ModuleThermo
-  implicit none
+subroutine getMolFraction(i, value, ierr) &
+    bind(C, name="TCAPI_getMolFraction")
 
-  integer, intent(in)::  i
-  integer, intent(out):: ierr
-  real(8), intent(out):: value
+    USE ModuleThermo
+    implicit none
 
-  ierr=0
-  value=0D0
-  if( i < 1 .OR. i > nSpecies )then
-     ierr = 1
-  else
-     value=dMolFraction(i)
-  endif
+    integer, intent(in)::  i
+    integer, intent(out):: ierr
+    real(8), intent(out):: value
 
-  return
+    ierr=0
+    value=0D0
+    if( i < 1 .OR. i > nSpecies )then
+        ierr = 1
+    else
+        value=dMolFraction(i)
+    endif
+
+    return
 end subroutine getMolFraction
 
-subroutine getChemicalPotential(i, value, ierr)
-  USE ModuleThermo
-  implicit none
+subroutine getChemicalPotential(i, value, ierr) &
+    bind(C, name="TCAPI_getChemicalPotential")
 
-  integer, intent(in)::  i
-  integer, intent(out):: ierr
-  real(8), intent(out):: value
+    USE ModuleThermo
+    implicit none
 
-  ierr=0
-  value=0D0
-  if( i < 1 .OR. i > nSpecies )then
-     ierr = 1
-  else
-     value=dChemicalPotential(i)
-  endif
+    integer, intent(in)::  i
+    integer, intent(out):: ierr
+    real(8), intent(out):: value
 
-  return
+    ierr=0
+    value=0D0
+    if( i < 1 .OR. i > nSpecies )then
+        ierr = 1
+    else
+        value=dChemicalPotential(i)
+    endif
+
+    return
 end subroutine getChemicalPotential
 
-subroutine getElementPotential(i, value, ierr)
-  USE ModuleThermoIO
-  USE ModuleThermo
-  implicit none
+subroutine getElementPotential(i, value, ierr) &
+    bind(C, name="TCAPI_getElementPotential")
 
-  integer, intent(in)::  i
-  integer, intent(out):: ierr
-  real(8), intent(out):: value
+    USE ModuleThermoIO
+    USE ModuleThermo
+    implicit none
 
-  integer k
+    integer, intent(in)::  i
+    integer, intent(out):: ierr
+    real(8), intent(out):: value
 
-  ierr=0
-  value=0D0
-  if( i < 1 .OR. i > nElements )then
-     ierr = 1
-     write(*,*) 'Element out of range ', i, nElements
-     do k=1,nElements
-        write(*,*) 'Element idx',k,' ',cElementName(k)
-     enddo
+    integer k
 
-  else
-     value=dElementPotential(i)*dTemperature*dIdealConstant
-  endif
+    ierr=0
+    value=0D0
+    if( i < 1 .OR. i > nElements )then
+        ierr = 1
+        write(*,*) 'Element out of range ', i, nElements
+        do k=1,nElements
+            write(*,*) 'Element idx',k,' ',cElementName(k)
+        enddo
 
-  return
+    else
+        value=dElementPotential(i)*dTemperature*dIdealConstant
+    endif
+
+    return
 
 end subroutine getElementPotential
 
-subroutine SetReinitRequested(iRequested)
+subroutine SetReinitRequested(iRequested) &
+    bind(C, name="TCAPI_setReinitRequested")
 
-  USE ModuleThermoIO, ONLY: lReinitRequested
+    USE ModuleThermoIO, ONLY: lReinitRequested
 
-  implicit none
+    implicit none
 
-  ! passing bool/logical was sketchy so just going with an int here
-  integer, intent(in)::  iRequested
-  if (iRequested == 0) then
-    lReinitRequested = .FALSE.
-  else
-    lReinitRequested = .TRUE.
-  end if
+    ! passing bool/logical was sketchy so just going with an int here
+    integer, intent(in)::  iRequested
+    if (iRequested == 0) then
+        lReinitRequested = .FALSE.
+    else
+        lReinitRequested = .TRUE.
+    end if
 
-  return
+    return
 
 end subroutine SetReinitRequested
 
-subroutine getReinitDataSizes(mElements,mSpecies)
-  USE ModuleThermo, ONLY: nElements, nSpecies
-  implicit none
+subroutine getReinitDataSizes(mElements, mSpecies) &
+    bind(C, name="TCAPI_getReinitDataSizes")
 
-  integer, intent(out)                           :: mElements, mSpecies
+    USE ModuleThermo, ONLY: nElements, nSpecies
+    implicit none
 
-  mElements = nElements
-  mSpecies = nSpecies
+    integer, intent(out)                           :: mElements, mSpecies
 
-  return
+    mElements = nElements
+    mSpecies = nSpecies
+
+    return
 
 end subroutine getReinitDataSizes
 
 subroutine reinitDataTcToMoose(mAssemblage,mMolesPhase,mElementPotential, &
-              mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable)
-  USE ModuleReinit
-  USE ModuleThermoIO
-  USE ModuleThermo, ONLY: nElements, nSpecies
-  implicit none
+    mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable)
+    USE ModuleReinit
+    USE ModuleThermoIO
+    USE ModuleThermo, ONLY: nElements, nSpecies
+    implicit none
 
-  integer, intent(out)                           :: mReinitAvailable
-  integer, intent(out), dimension(nElements)     :: mAssemblage
-  real(8), intent(out), dimension(nElements)     :: mMolesPhase, mElementPotential
-  real(8), intent(out), dimension(nSpecies)      :: mChemicalPotential, mMolFraction
-  integer, intent(out), dimension(0:168) :: mElementsUsed
-
-
-  if (lReinitAvailable) then
-    mAssemblage = iAssemblage_Old
-    mMolesPhase = dMolesPhase_Old
-    mElementPotential = dElementPotential_Old
-    mChemicalPotential = dChemicalPotential_Old
-    mMolFraction =  dMolFraction_Old
-    mElementsUsed = iElementsUsed_Old
-    mReinitAvailable = 1
-  else
-    mReinitAvailable = 0
-  end if
+    integer, intent(out)                           :: mReinitAvailable
+    integer, intent(out), dimension(nElements)     :: mAssemblage
+    real(8), intent(out), dimension(nElements)     :: mMolesPhase, mElementPotential
+    real(8), intent(out), dimension(nSpecies)      :: mChemicalPotential, mMolFraction
+    integer, intent(out), dimension(0:168) :: mElementsUsed
 
 
-  return
+    if (lReinitAvailable) then
+        mAssemblage = iAssemblage_Old
+        mMolesPhase = dMolesPhase_Old
+        mElementPotential = dElementPotential_Old
+        mChemicalPotential = dChemicalPotential_Old
+        mMolFraction =  dMolFraction_Old
+        mElementsUsed = iElementsUsed_Old
+        mReinitAvailable = 1
+    else
+        mReinitAvailable = 0
+    end if
+
+
+    return
 
 end subroutine reinitDataTcToMoose
 
 subroutine reinitDataTcFromMoose(mElements,mSpecies,mAssemblage,mMolesPhase, &
-              mElementPotential,mChemicalPotential,mMolFraction,mElementsUsed)
-  USE ModuleReinit
-  USE ModuleThermoIO
-  USE ModuleThermo
-  implicit none
+    mElementPotential,mChemicalPotential,mMolFraction,mElementsUsed)
+    USE ModuleReinit
+    USE ModuleThermoIO
+    USE ModuleThermo
+    implicit none
 
-  integer, intent(in)                            :: mElements, mSpecies
-  integer, intent(in), dimension(mElements)      :: mAssemblage
-  real(8), intent(in), dimension(mElements)      :: mMolesPhase, mElementPotential
-  real(8), intent(in), dimension(mSpecies)       :: mChemicalPotential, mMolFraction
-  integer, intent(in), dimension(0:168)  :: mElementsUsed
+    integer, intent(in)                            :: mElements, mSpecies
+    integer, intent(in), dimension(mElements)      :: mAssemblage
+    real(8), intent(in), dimension(mElements)      :: mMolesPhase, mElementPotential
+    real(8), intent(in), dimension(mSpecies)       :: mChemicalPotential, mMolFraction
+    integer, intent(in), dimension(0:168)  :: mElementsUsed
 
-  allocate(dMolesPhase_Old(mElements),dChemicalPotential_Old(mSpecies),dElementPotential_Old(mElements),&
-  dMolFraction_Old(mSpecies))
-  allocate(iAssemblage_Old(mElements))
-  ! allocate(iElementsUsed_Old(0:168))
+    allocate(dMolesPhase_Old(mElements),dChemicalPotential_Old(mSpecies),dElementPotential_Old(mElements),&
+        dMolFraction_Old(mSpecies))
+    allocate(iAssemblage_Old(mElements))
+    ! allocate(iElementsUsed_Old(0:168))
 
-  iAssemblage_Old = mAssemblage
-  dMolesPhase_Old = mMolesPhase
-  dElementPotential_Old = mElementPotential
-  dChemicalPotential_Old = mChemicalPotential
-  dMolFraction_Old = mMolFraction
-  iElementsUsed_Old = mElementsUsed
-  lReinitAvailable = .TRUE.
+    iAssemblage_Old = mAssemblage
+    dMolesPhase_Old = mMolesPhase
+    dElementPotential_Old = mElementPotential
+    dChemicalPotential_Old = mChemicalPotential
+    dMolFraction_Old = mMolFraction
+    iElementsUsed_Old = mElementsUsed
+    lReinitAvailable = .TRUE.
 
-  return
+    return
 
 end subroutine reinitDataTcFromMoose
 
-subroutine GetMolesPhase(mMolesPhase)
-  USE ModuleThermo, ONLY: nElements, dMolesPhase
-  implicit none
+subroutine GetMolesPhase(mMolesPhase) &
+    bind(C, name="TCAPI_getMolesPhase")
 
-  real(8), intent(out), dimension(nElements)     :: mMolesPhase
+    USE ModuleThermo, ONLY: nElements, dMolesPhase
+    implicit none
 
-  mMolesPhase = dMolesPhase
+    real(8), intent(out), dimension(nElements)     :: mMolesPhase
 
-  return
+    mMolesPhase = dMolesPhase
+
+    return
 
 end subroutine GetMolesPhase
 
@@ -701,59 +794,64 @@ subroutine GibbsEnergyOfReinitData(mGibbsEnergyOut)
     end do
 
     call GibbsEnergy(nConPhasesReinit, nSolnPhasesReinit, iAssemblage_Old, &
-                     dMolesPhase_Old, dMolFraction_Old, mGibbsEnergyOut)
+        dMolesPhase_Old, dMolFraction_Old, mGibbsEnergyOut)
 
     return
 
 end subroutine GibbsEnergyOfReinitData
 
-subroutine GetAssemblage(mAssemblage)
-  USE ModuleThermo, ONLY: nElements, iAssemblage
-  implicit none
+subroutine GetAssemblage(mAssemblage) &
+    bind(C, name="TCAPI_getAssemblage")
 
-  integer, intent(out), dimension(nElements)     :: mAssemblage
+    USE ModuleThermo, ONLY: nElements, iAssemblage
+    implicit none
 
-  mAssemblage = iAssemblage
+    integer, intent(out), dimension(nElements)     :: mAssemblage
 
-  return
+    mAssemblage = iAssemblage
+
+    return
 
 end subroutine GetAssemblage
 
-subroutine GetAllElementPotential(mElementPotential)
-  USE ModuleThermo, ONLY: nElements, dElementPotential
-  implicit none
+subroutine GetAllElementPotential(mElementPotential) &
+    bind(C, name="TCAPI_getAllElementPotential")
 
-  real(8), intent(out), dimension(nElements)     :: mElementPotential
+    USE ModuleThermo, ONLY: nElements, dElementPotential
+    implicit none
 
-  mElementPotential = dElementPotential
+    real(8), intent(out), dimension(nElements)     :: mElementPotential
 
-  return
+    mElementPotential = dElementPotential
+
+    return
 
 end subroutine GetAllElementPotential
 
-subroutine GetElementFraction(iAtom, dFrac)
+subroutine GetElementFraction(iAtom, dFrac) &
+    bind(C, name="TCAPI_getElementFraction")
 
-  USE ModuleThermoIO, ONLY: dElementMass
-  USE ModuleThermo,   ONLY: nElementsPT
+    USE ModuleThermoIO, ONLY: dElementMass
+    USE ModuleThermo,   ONLY: nElementsPT
 
-  implicit none
+    implicit none
 
-  integer, intent(in) ::  iAtom
-  real(8), intent(out)::  dFrac
-  real(8)             ::  dTotalElementMass
-  integer :: i
+    integer, intent(in) ::  iAtom
+    real(8), intent(out)::  dFrac
+    real(8)             ::  dTotalElementMass
+    integer :: i
 
-  if( iAtom <= 0 .or. iAtom > 118 )then
-      write(*,*) 'Error in GetElementFraction ', iAtom
-      stop
-  else
-      dTotalElementMass = 0D0
-      do i = 1, nElementsPT
-          dTotalElementMass = dTotalElementMass + dElementMass(i)
-      end do
-      dFrac = dElementMass(iAtom) / dTotalElementMass
-  end if
+    if( iAtom <= 0 .or. iAtom > 118 )then
+        write(*,*) 'Error in GetElementFraction ', iAtom
+        stop
+    else
+        dTotalElementMass = 0D0
+        do i = 1, nElementsPT
+            dTotalElementMass = dTotalElementMass + dElementMass(i)
+        end do
+        dFrac = dElementMass(iAtom) / dTotalElementMass
+    end if
 
-  return
+    return
 
 end subroutine GetElementFraction

--- a/src/postprocess/CouplingUtilities.f90
+++ b/src/postprocess/CouplingUtilities.f90
@@ -1,35 +1,21 @@
-subroutine SetThermoFileName(cFileName,lcFileName)
+subroutine SetThermoFileName(cFileName, lcFileName) &
+  bind(C, name="setThermoFileName")
 
   USE ModuleThermoIO, ONLY: cThermoFileName
+  USE,INTRINSIC :: ISO_C_BINDING
 
   implicit none
 
-  character(*), intent(in)::  cFileName
-  integer, intent(in) :: lcFileName
-  character(120) :: cFileNameLen
+  character(kind=c_char,len=1), target, intent(in) :: cFileName(*)
+  integer(c_size_t), intent(in), value             :: lcFileName
+  character(kind=c_char,len=lcFileName), pointer :: fFileName
 
-  cFileNameLen = cFileName!(1:min(120,lcFileName))
-  cThermoFileName       = trim(cFileNameLen(1:lcFileName))
+  call c_f_pointer(cptr=c_loc(cFileName), fptr=fFileName)
+  cThermoFileName       = fFileName
 
   return
 
 end subroutine SetThermoFileName
-
-subroutine SetThermoFileNameBISON(cFileName)
-
-  USE ModuleThermoIO, ONLY: cThermoFileName
-
-  implicit none
-
-  character(120), intent(in)::  cFileName
-  character(120) :: cFileNameLen
-
-  cFileNameLen = cFileName(1:120)
-  cThermoFileName       = trim(cFileNameLen)
-
-  return
-
-end subroutine SetThermoFileNameBISON
 
 subroutine SetThermoFileNameFortran(cFileName)
 
@@ -45,55 +31,65 @@ subroutine SetThermoFileNameFortran(cFileName)
 
 end subroutine SetThermoFileNameFortran
 
-subroutine SetUnitTemperature(cUnitTemperature)
+subroutine SetUnitTemperature(cUnitTemperature, lcUnitTemperature) &
+  bind(C, name="setUnitTemperature")
 
   USE ModuleThermoIO, ONLY: cInputUnitTemperature
+  USE,INTRINSIC :: ISO_C_BINDING
 
   implicit none
 
-  character(15), intent(in)::  cUnitTemperature
-  character(15) :: cUnitTemperatureLen
+  character(kind=c_char,len=1), target, intent(in)      :: cUnitTemperature(*)
+  integer(c_size_t), intent(in), value                  :: lcUnitTemperature
+  character(kind=c_char,len=lcUnitTemperature), pointer :: fUnitTemperature
 
-  cUnitTemperatureLen = cUnitTemperature(1:min(15,len(cUnitTemperature)))
-  cInputUnitTemperature       = trim(cUnitTemperatureLen)
+  call c_f_pointer(cptr=c_loc(cUnitTemperature), fptr=fUnitTemperature)
+  cInputUnitTemperature = fUnitTemperature
 
   return
 
 end subroutine SetUnitTemperature
 
-subroutine SetUnitPressure(cUnitPressure)
+subroutine SetUnitPressure(cUnitPressure, lcUnitPressure) &
+  bind(C, name="setUnitPressure")
 
   USE ModuleThermoIO, ONLY: cInputUnitPressure
+  USE,INTRINSIC :: ISO_C_BINDING
 
   implicit none
 
-  character(15), intent(in)::  cUnitPressure
-  character(15) :: cUnitPressureLen
+  character(kind=c_char,len=1), target, intent(in)   :: cUnitPressure(*)
+  integer(c_size_t), intent(in), value               :: lcUnitPressure
+  character(kind=c_char,len=lcUnitPressure), pointer :: fUnitPressure
 
-  cUnitPressureLen = cUnitPressure(1:min(15,len(cUnitPressure)))
-  cInputUnitPressure       = trim(cUnitPressureLen)
+  call c_f_pointer(cptr=c_loc(cUnitPressure), fptr=fUnitPressure)
+  cInputUnitPressure = fUnitPressure
 
   return
 
 end subroutine SetUnitPressure
 
-subroutine SetUnitMass(cUnitMass)
+subroutine SetUnitMass(cUnitMass, lcUnitMass) &
+  bind(C, name="setUnitMass")
 
   USE ModuleThermoIO, ONLY: cInputUnitMass
+  USE,INTRINSIC :: ISO_C_BINDING
 
   implicit none
 
-  character(15), intent(in)::  cUnitMass
-  character(15) :: cUnitMassLen
+  character(kind=c_char,len=1), target, intent(in)   :: cUnitMass(*)
+  integer(c_size_t), intent(in), value               :: lcUnitMass
+  character(kind=c_char,len=lcUnitMass), pointer :: fUnitMass
 
-  cUnitMassLen = cUnitMass(1:min(15,len(cUnitMass)))
-  cInputUnitMass       = trim(cUnitMassLen)
+  call c_f_pointer(cptr=c_loc(cUnitMass), fptr=fUnitMass)
+  cInputUnitMass = fUnitMass
 
   return
 
 end subroutine SetUnitMass
 
-subroutine SetStandardUnits
+subroutine SetStandardUnits() &
+  bind(C, name="setStandardUnits")
 
   USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
 
@@ -107,7 +103,8 @@ subroutine SetStandardUnits
 
 end subroutine SetStandardUnits
 
-subroutine SetModelicaUnits
+subroutine SetModelicaUnits() &
+  bind(C, name="setModelicaUnits")
 
   USE ModuleThermoIO, ONLY: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
 
@@ -157,7 +154,8 @@ subroutine SetUnits(cTemperature, cPressure, cMass)
 
 end subroutine SetUnits
 
-subroutine SetTemperaturePressure(dTemp, dPress)
+subroutine SetTemperaturePressure(dTemp, dPress) &
+  bind(C, name="setTemperaturePressure")
 
   USE ModuleThermoIO, ONLY: dTemperature, dPressure
 
@@ -210,7 +208,9 @@ subroutine PresetElementMass(iAtom, dMass)
 
 end subroutine PresetElementMass
 
-subroutine SetElementMass(iAtom, dMass)
+subroutine SetElementMass(iAtom, dMass) &
+  bind(C, name="setElementMass")
+
 
   USE ModuleThermoIO, ONLY: dElementMass, lPreset
 
@@ -253,7 +253,8 @@ subroutine GetElementMass(iAtom, dMass)
 
 end subroutine GetElementMass
 
-subroutine CheckINFOThermo(dbginfo)
+subroutine CheckINFOThermo(dbginfo) &
+  bind(C, name="checkInfoThermo")
 
   USE ModuleThermoIO, ONLY: INFOThermo
 
@@ -322,7 +323,8 @@ subroutine SolPhaseParse(iElem, dMolSum)
     return
 end subroutine SolPhaseParse
 
-subroutine SSParseCSDataFile
+subroutine SSParseCSDataFile() &
+    bind(C, name="sSParseCSDataFile")
 
     USE ModuleThermoIO
     USE ModuleSS

--- a/src/postprocess/GetElementMoleFractionInPhase.f90
+++ b/src/postprocess/GetElementMoleFractionInPhase.f90
@@ -39,24 +39,27 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetElementMoleFractionInPhase(cElement, lcElement, cPhase, lcPhase, dMolesOut, INFO)
+subroutine GetElementMoleFractionInPhase(cElement, lcElement, cPhase, lcPhase, dMolesOut, INFO) &
+    bind(C, name="TCAPI_getElementMoleFractionInPhase")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
     integer,       intent(out)   :: INFO
-    integer                      :: i, j, k, l
     real(8),       intent(out)   :: dMolesOut
-    character(25), intent(in)    :: cPhase
-    character(3),  intent(in)    :: cElement
-    integer, intent(in)          :: lcPhase, lcElement
-    character(25)                :: cTempPhase, cTempElement, cSearchPhase, cSearchElement
+    character(kind=c_char,len=1), target, intent(in) :: cPhase(*), cElement(*)
+    integer(c_size_t), intent(in), value             :: lcPhase, lcElement
+    character(kind=c_char,len=lcPhase), pointer      :: fPhase
+    character(kind=c_char,len=lcElement), pointer    :: fElement
+    character(25)                :: cTempPhase, cTempElement
+    integer                      :: i, j, k, l
     real(8)                      :: dSum
 
-    cSearchPhase = TRIM(cPhase(1:min(25,lcPhase)))
-    cSearchElement = TRIM(cElement(1:min(3,lcElement)))
+    call c_f_pointer(cptr=c_loc(cPhase), fptr=fPhase)
+    call c_f_pointer(cptr=c_loc(cElement), fptr=fElement)
 
     ! Initialize variables:
     INFO      = 0
@@ -66,16 +69,16 @@ subroutine GetElementMoleFractionInPhase(cElement, lcElement, cPhase, lcPhase, d
 
     LOOP_Elements: do i = 1, nElements
         cTempElement = ADJUSTL(cElementName(i))
-        if (cTempElement == cSearchElement) then
+        if (cTempElement == fElement) then
             k = i
             exit LOOP_Elements
         end if
     end do LOOP_Elements
 
     if (k == 0) then
-       ! This element was not found.  Report an error:
-       INFO = 1
-       return
+        ! This element was not found.  Report an error:
+        INFO = 1
+        return
     end if
 
     ! Only proceed if Thermochimica solved successfully:
@@ -85,7 +88,7 @@ subroutine GetElementMoleFractionInPhase(cElement, lcElement, cPhase, lcPhase, d
             cTempPhase = ADJUSTL(cSolnPhaseName(i))
 
             ! Loop through species in this phase:
-            if (cTempPhase == cSearchPhase) then
+            if (cTempPhase == fPhase) then
                 ! Solution phase found. Now compute sums.
                 LOOP_Species: do j = nSpeciesPhase(i-1) + 1, nSpeciesPhase(i)
                     dMolesOut = dMolesOut + dMolFraction(j) * dStoichSpecies(j,k)

--- a/src/postprocess/GetOutputChemPot.f90
+++ b/src/postprocess/GetOutputChemPot.f90
@@ -38,7 +38,7 @@
 
 
 subroutine GetOutputChemPot(cElementNameRequest, lcElementNameRequest, dElementChemPot, INFO) &
-    bind(C, name="getOutputChemPot")
+    bind(C, name="TCAPI_getOutputChemPot")
 
     USE ModuleThermo
     USE ModuleThermoIO

--- a/src/postprocess/GetOutputChemPot.f90
+++ b/src/postprocess/GetOutputChemPot.f90
@@ -37,19 +37,23 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetOutputChemPot(cElementNameRequest, dElementChemPot, INFO)
+subroutine GetOutputChemPot(cElementNameRequest, lcElementNameRequest, dElementChemPot, INFO) &
+    bind(C, name="getOutputChemPot")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
     integer,      intent(out)   :: INFO
-    integer                     :: i, j
     real(8),      intent(out)   :: dElementChemPot
-    character(*), intent(in)    :: cElementNameRequest
-    character(3)                :: cElementNameUse
+    character(kind=c_char,len=1), target, intent(in)         :: cElementNameRequest(*)
+    integer(c_size_t), intent(in), value                     :: lcElementNameRequest
+    character(kind=c_char,len=lcElementNameRequest), pointer :: cElementNameUse
+    integer                     :: i, j
 
+    call c_f_pointer(cptr=c_loc(cElementNameRequest), fptr=cElementNameUse)
 
     ! Initialize variables:
     INFO            = 0
@@ -57,10 +61,6 @@ subroutine GetOutputChemPot(cElementNameRequest, dElementChemPot, INFO)
 
     ! Only proceed if Thermochimica solved successfully:
     if (INFOThermo == 0) then
-
-        ! Remove trailing blanks:
-        cElementNameUse = cElementNameRequest
-        cElementNameUse = TRIM(cElementNameUse)
 
         ! Loop through elements to find the one corresponding to the element
         ! being requested:

--- a/src/postprocess/GetOutputMolSpecies.f90
+++ b/src/postprocess/GetOutputMolSpecies.f90
@@ -39,22 +39,24 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetOutputMolSpecies(cSpeciesOut, lcSpeciesOut, dMolFractionOut, dMolesOut, INFO)
+subroutine GetOutputMolSpecies(cSpeciesOut, lcSpeciesOut, dMolFractionOut, dMolesOut, INFO) &
+    bind(C, name="getOutputMolSpecies")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
     integer,       intent(out)   :: INFO
-    integer                      :: i, k
     real(8),       intent(out)   :: dMolFractionOut, dMolesOut
-    character(30), intent(inout) :: cSpeciesOut
-    integer                      :: lcSpeciesOut
-    character(30)                :: cTemp, cSearch
+    character(kind=c_char,len=1), target, intent(in) :: cSpeciesOut(*)
+    integer(c_size_t), intent(in), value             :: lcSpeciesOut
+    character(kind=c_char,len=lcSpeciesOut), pointer :: cSearch
+    integer                      :: i, k
+    character(30)                :: cTemp
 
-    cSearch = cSpeciesOut(1:min(30,lcSpeciesOut))
-    cSearch = TRIM(cSearch)
+    call c_f_pointer(cptr=c_loc(cSpeciesOut), fptr=cSearch)
 
     ! Initialize variables:
     INFO            = 0
@@ -63,7 +65,6 @@ subroutine GetOutputMolSpecies(cSpeciesOut, lcSpeciesOut, dMolFractionOut, dMole
     k=0
     ! Only proceed if Thermochimica solved successfully:
     if (INFOThermo == 0) then
-       ! Remove trailing blanks:
         LOOP_SPECIES: do i = 1, nSpecies
 
            ! Remove leading blanks:

--- a/src/postprocess/GetOutputMolSpecies.f90
+++ b/src/postprocess/GetOutputMolSpecies.f90
@@ -40,7 +40,7 @@
 
 
 subroutine GetOutputMolSpecies(cSpeciesOut, lcSpeciesOut, dMolFractionOut, dMolesOut, INFO) &
-    bind(C, name="getOutputMolSpecies")
+    bind(C, name="TCAPI_getOutputMolSpecies")
 
     USE ModuleThermo
     USE ModuleThermoIO

--- a/src/postprocess/GetOutputMolSpeciesPhase.f90
+++ b/src/postprocess/GetOutputMolSpeciesPhase.f90
@@ -39,25 +39,26 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetOutputMolSpeciesPhase(cPhase, lcPhase, cSpecies, lcSpecies, dMolFractionOut, INFO)
+subroutine GetOutputMolSpeciesPhase(cPhase, lcPhase, cSpecies, lcSpecies, dMolFractionOut, INFO) &
+    bind(C, name="getOutputMolSpeciesPhase")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
-    integer,       intent(out)   :: INFO
-    integer                      :: i, j, k, iPhaseInd
-    real(8),       intent(out)   :: dMolFractionOut
-    character(*),  intent(in)    :: cPhase, cSpecies
-    integer                      :: lcPhase, lcSpecies
-    character(30)                :: cTempPhase, cTempSpecies, cSearchPhase, cSearchSpecies
+    integer, intent(out)   :: INFO
+    real(8), intent(out)   :: dMolFractionOut
+    character(kind=c_char,len=1), target, intent(in) :: cPhase(*), cSpecies(*)
+    integer(c_size_t), intent(in), value             :: lcPhase, lcSpecies
+    character(kind=c_char,len=lcPhase), pointer      :: cSearchPhase
+    character(kind=c_char,len=lcSpecies), pointer    :: cSearchSpecies
+    integer                :: i, j, k, iPhaseInd
+    character(30)          :: cTempPhase, cTempSpecies
 
-    cSearchPhase = cPhase!TRIM(cPhase(1:min(30,lcPhase)))
-    cSearchSpecies = cSpecies!TRIM(cSpecies(1:min(30,lcSpecies)))
-
-    cSearchPhase = TRIM(cSearchPhase(1:min(30,lcPhase)))
-    cSearchSpecies = TRIM(cSearchSpecies(1:min(30,lcSpecies)))
+    call c_f_pointer(cptr=c_loc(cPhase), fptr=cSearchPhase)
+    call c_f_pointer(cptr=c_loc(cSpecies), fptr=cSearchSpecies)
 
     ! Initialize variables:
     INFO            = 0

--- a/src/postprocess/GetOutputMolSpeciesPhase.f90
+++ b/src/postprocess/GetOutputMolSpeciesPhase.f90
@@ -40,7 +40,7 @@
 
 
 subroutine GetOutputMolSpeciesPhase(cPhase, lcPhase, cSpecies, lcSpecies, dMolFractionOut, INFO) &
-    bind(C, name="getOutputMolSpeciesPhase")
+    bind(C, name="TCAPI_getOutputMolSpeciesPhase")
 
     USE ModuleThermo
     USE ModuleThermoIO

--- a/src/postprocess/GetPhaseIndex.f90
+++ b/src/postprocess/GetPhaseIndex.f90
@@ -36,31 +36,30 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetPhaseIndex(cPhaseName, lcPhaseName, iIndexOut, INFO)
+subroutine GetPhaseIndex(cPhaseName, lcPhaseName, iIndexOut, INFO) &
+    bind(C, name="getPhaseIndex")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
     integer,       intent(out)   :: INFO
-    integer                      :: i, k
     integer,       intent(out)   :: iIndexOut
-    character(*),  intent(in)    :: cPhaseName
-    integer                      :: lcPhaseName
-    character(25)                :: cTemp, cTempPhase
-    cTemp = cPhaseName(1:min(25,lcPhaseName))
+    character(kind=c_char,len=1), target, intent(in) :: cPhaseName(*)
+    integer(c_size_t), intent(in), value             :: lcPhaseName
+    character(kind=c_char,len=lcPhaseName), pointer  :: cTemp
+    integer                      :: i, k
+    character(25)                :: cTempPhase
+
+    call c_f_pointer(cptr=c_loc(cPhaseName), fptr=cTemp)
 
     ! Initialize variables:
     INFO          = 0
 
     ! Only proceed if Thermochimica solved successfully:
     if (INFOThermo == 0) then
-
-        ! Remove trailing blanks:
-        ! cSolnOut    = TRIM(cSolnOut)
-        cTemp    = TRIM(cTemp)
-        cTemp    = ADJUSTL(cTemp)
 
         ! Loop through stable soluton phases to find the one corresponding to the
         ! solution phase being requested:

--- a/src/postprocess/GetPhaseIndex.f90
+++ b/src/postprocess/GetPhaseIndex.f90
@@ -37,7 +37,7 @@
 
 
 subroutine GetPhaseIndex(cPhaseName, lcPhaseName, iIndexOut, INFO) &
-    bind(C, name="getPhaseIndex")
+    bind(C, name="TCAPI_getPhaseIndex")
 
     USE ModuleThermo
     USE ModuleThermoIO

--- a/src/postprocess/GetSUBLSiteMol.f90
+++ b/src/postprocess/GetSUBLSiteMol.f90
@@ -50,24 +50,25 @@
 !-------------------------------------------------------------------------------
 
 
-subroutine GetSUBLSiteMol(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, dSiteMolOut, INFO)
+subroutine GetSUBLSiteMol(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, dSiteMolOut, INFO) &
+    bind(C, name="TCAPI_getSublSiteMol")
 
     USE ModuleThermo
     USE ModuleThermoIO
+    USE,INTRINSIC :: ISO_C_BINDING
 
     implicit none
 
     integer,       intent(out)   :: INFO
-    integer                      :: i, j, k, iph
-    integer                      :: iSublatticeOut, iConstituentOut
     real(8),       intent(out)   :: dSiteMolOut
+    integer                      :: iSublatticeOut, iConstituentOut
+    character(kind=c_char,len=1), target, intent(in) :: cSolnOut(*)
+    integer(c_size_t), intent(in), value             :: lcSolnOut
+    character(kind=c_char,len=lcSolnOut), pointer    :: fSolnOut
+    integer                      :: i, j, k, iph
     real(8)                      :: dSiteFractionOut, dStoichCoefOut, dSolnMolOut
-    character(*),  intent(in)    :: cSolnOut
-    integer                      :: lcSolnOut
-    character(15)                :: cTemp
 
-    cTemp = cSolnOut(1:min(15,lcSolnOut))
-!    cTemp = cSolnOut(1:min(15,len(cSolnOut)))
+    call c_f_pointer(cptr=c_loc(cSolnOut), fptr=fSolnOut)
 
     ! Initialize variables:
     INFO             = 0
@@ -75,10 +76,6 @@ subroutine GetSUBLSiteMol(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, 
 
     ! Only proceed if Thermochimica solved successfully:
     if (INFOThermo == 0) then
-
-        ! Remove trailing blanks:
-        ! cSolnOut    = TRIM(cSolnOut)
-        cTemp    = TRIM(cTemp)
 
         ! Loop through stable soluton phases to find the one corresponding to the
         ! solution phase being requested:
@@ -91,7 +88,7 @@ subroutine GetSUBLSiteMol(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, 
 
 !           write(*,*) 'O ', cSolnOut(1:15), '--', cTemp, len(cTemp), ' = ', cSolnPhaseName(k)
            ! if (cSolnOut == cSolnPhaseName(k)) then
-           if (cTemp == cSolnPhaseName(k)) then
+           if (fSolnOut == cSolnPhaseName(k)) then
               ! Solution phase found.  Record integer index and exit loop.
               j = k
 

--- a/src/postprocess/checkUnits.h
+++ b/src/postprocess/checkUnits.h
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include "MooseApp.h"
+
+namespace Thermochimica
+{
+
+  unsigned int
+  checkTemperature(const std::string &temperature_unit);
+
+  unsigned int
+  checkPressure(const std::string &pressure_unit);
+
+  unsigned int
+  checkMass(const std::string &mass_unit);
+
+  unsigned int
+  atomicNumber(const std::string &element);
+
+  std::string
+  elementName(unsigned int atomic_number);
+
+}


### PR DESCRIPTION
Refs #103

This PR together with an app level change like this:

```
-      char cPhaseName[25];
-      int lcPhaseName = sizeof(cPhaseName);
-      ConvertToFortran(cPhaseName, lcPhaseName, _sp_phase_name[i].c_str());
-      char cSpeciesName[25];
-      int lcSpeciesName = sizeof(cSpeciesName);
-      ConvertToFortran(cSpeciesName, lcSpeciesName, _sp_species_name[i].c_str());
-      FORTRAN_CALL(Thermochimica::getoutputmolspeciesphase)
-      (cPhaseName,
-       &lcPhaseName,
-       cSpeciesName,
-       &lcSpeciesName,
-       &d._species_fractions[i],
-       &idbg,
-       30,
-       30);
+      Thermochimica::getOutputMolSpeciesPhase(_sp_phase_name[i].c_str(),
+                                              _sp_phase_name[i].length(),
+                                              _sp_species_name[i].c_str(),
+                                              _sp_species_name[i].length(),
+                                              &d._species_fractions[i],
+                                              &idbg);
```

seems to do the trick.