### PR TITLE
GEM iteration in reinit data 

### DIFF
--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -476,7 +476,7 @@ namespace Thermochimica
   getReinitData()
   {
     ReinitializationData data;
-    int available;
+    int available, iterations;
     auto [elements, species] = getReinitDataSizes();
     data.assemblage.resize(elements);
     data.molesPhase.resize(elements);
@@ -484,9 +484,17 @@ namespace Thermochimica
     data.chemicalPotential.resize(species);
     data.moleFraction.resize(species);
 
-    TCAPI_getReinitData(data.assemblage.data(), data.molesPhase.data(), data.elementPotential.data(), data.chemicalPotential.data(), data.moleFraction.data(), data.elementsUsed.data(), &available);
+    TCAPI_getReinitData(data.assemblage.data(),
+                        data.molesPhase.data(),
+                        data.elementPotential.data(),
+                        data.chemicalPotential.data(),
+                        data.moleFraction.data(),
+                        data.elementsUsed.data(),
+                        &available,
+                        &iterations);
 
     data.reinitAvailable = available;
+    data.GEM_iterations = iterations;
 
     return data;
   }

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -101,6 +101,7 @@ namespace Thermochimica
     int nPeriodicTable = 169;
     std::vector<int> elementsUsed = std::vector<int>(nPeriodicTable);
     bool reinitAvailable;
+    int GEM_iterations;
   };
 
   ReinitializationData getReinitData();

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -85,7 +85,7 @@ extern "C"
   char *TCAPI_getMqmqaPairAtIndex(int *, int *, int *);
 
   // MOOSE reinit functions
-  void TCAPI_getReinitData(int *, double *, double *, double *, double *, int *, int *);
+  void TCAPI_getReinitData(int *, double *, double *, double *, double *, int *, int *, int *);
   void TCAPI_setReinitData(const int *, const int *, const int *, const double *, const double *, const double *, const double *, const int *);
 
   // Heat capacity, enthalpy, and entropy

--- a/src/api/CouplingUtilities.f90
+++ b/src/api/CouplingUtilities.f90
@@ -603,13 +603,14 @@ subroutine getReinitDataSizes(mElements,mSpecies)
 end subroutine getReinitDataSizes
 
 subroutine getReinitData(mAssemblage,mMolesPhase,mElementPotential, &
-              mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable)
+              mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable,mIterations)
   USE ModuleReinit
   USE ModuleThermoIO
   USE ModuleThermo, ONLY: nElements, nSpecies
+  USE ModuleGEMSolver, ONLY: iterGlobal
   implicit none
 
-  integer, intent(out)                           :: mReinitAvailable
+  integer, intent(out)                           :: mReinitAvailable, mIterations
   integer, intent(out), dimension(nElements)     :: mAssemblage
   real(8), intent(out), dimension(nElements)     :: mMolesPhase, mElementPotential
   real(8), intent(out), dimension(nSpecies)      :: mChemicalPotential, mMolFraction
@@ -624,6 +625,7 @@ subroutine getReinitData(mAssemblage,mMolesPhase,mElementPotential, &
     mMolFraction =  dMolFraction_Old
     mElementsUsed = iElementsUsed_Old
     mReinitAvailable = 1
+    mIterations = iterGlobal
   else
     mReinitAvailable = 0
   end if

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -668,7 +668,7 @@ subroutine getReinitDataSizesISO(mElements, mSpecies) &
 end subroutine getReinitDataSizesISO
 
 subroutine getReinitDataISO(mAssemblage,mMolesPhase,mElementPotential, &
-    mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable) &
+    mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable, mIterations) &
     bind(C, name="TCAPI_getReinitData")
 
     USE,INTRINSIC :: ISO_C_BINDING
@@ -676,14 +676,14 @@ subroutine getReinitDataISO(mAssemblage,mMolesPhase,mElementPotential, &
     USE ModuleThermo, ONLY: nElements, nSpecies
     implicit none
 
-    integer(C_INT), intent(out)                           :: mReinitAvailable
+    integer(C_INT), intent(out)                           :: mReinitAvailable, mIterations
     integer(C_INT), intent(out), dimension(nElements)     :: mAssemblage
     real(C_DOUBLE), intent(out), dimension(nElements)     :: mMolesPhase, mElementPotential
     real(C_DOUBLE), intent(out), dimension(nSpecies)      :: mChemicalPotential, mMolFraction
     integer(C_INT), intent(out), dimension(0:168)         :: mElementsUsed
 
     call getReinitData(mAssemblage,mMolesPhase,mElementPotential, &
-            mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable)
+            mChemicalPotential,mMolFraction,mElementsUsed,mReinitAvailable,mIterations)
 
     return
 


### PR DESCRIPTION
Add number of GEM iterations to reinit data for comparison when caching. This would be useful in deciding when to add new calculations to set of cached values.