### PR TITLE
Fix thermochimica API epsilon to compile time value

### DIFF
--- a/src/api/CouplingUtilities.f90
+++ b/src/api/CouplingUtilities.f90
@@ -823,7 +823,6 @@ subroutine InitThermoAPI
   implicit none
 
   call InitThermo
-  call SetMachineDefaultTolerances
   call ApplyToleranceOverride
 
   return
@@ -906,7 +905,7 @@ end subroutine SetMassBalanceTolerance
 !   Smaller x_min  =>  larger dTolerance(1)  =>  looser mass balance
 !   convergence criterion, but trace elements are not discarded.
 !
-! Under the API defaults, dToleranceEpsilon is the actual machine epsilon.
+! Under the API defaults, dToleranceEpsilon is the compile-time default.
 !-----------------------------------------------------------------------
 subroutine SetMinMoleFraction(dMinMolFrac)
 

--- a/src/api/CouplingUtilities.f90
+++ b/src/api/CouplingUtilities.f90
@@ -818,7 +818,7 @@ end subroutine SetGibbsMinCheck
 
 subroutine InitThermoAPI
 
-  USE ModuleThermoTolerance, ONLY: SetMachineDefaultTolerances, ApplyToleranceOverride
+  USE ModuleThermoTolerance, ONLY: ApplyToleranceOverride
 
   implicit none
 


### PR DESCRIPTION
Current API setup uses the default tolerances of thermochimica over the ones set in the MOOSE thermochimica.mk file. This PR fixes it.