### PR TITLE
Add indexed Thermochimica result APIs

### DIFF
--- a/src/Thermochimica-c.C
+++ b/src/Thermochimica-c.C
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <math.h>
+#include "Thermochimica.h"
 #include <cstring>
 #include <map>
-#include "Thermochimica.h"
+#include <math.h>
+#include <stdio.h>
 
 void SetThermoFilename(const char *filename)
 {
@@ -61,9 +61,23 @@ void GetOutputMolSpeciesPhase(const char *phaseName, const char *speciesName, do
   TCAPI_getOutputMolSpeciesPhase(phaseName, strlen(phaseName), speciesName, strlen(speciesName), moleFraction, info);
 }
 
+void GetOutputMolSpeciesPhaseByIndex(int phaseSystemIndex, int speciesSystemIndex, double *moleFraction, int *info)
+{
+  ++phaseSystemIndex;
+  ++speciesSystemIndex;
+  TCAPI_getOutputMolSpeciesPhaseByIndex(&phaseSystemIndex, &speciesSystemIndex, moleFraction, info);
+}
+
 void GetElementMolesInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
 {
   TCAPI_getElementMolesInPhase(elementName, strlen(elementName), phaseName, strlen(phaseName), molesElement, info);
+}
+
+void GetElementMolesInPhaseByIndex(int elementSystemIndex, int phaseSystemIndex, double *molesElement, int *info)
+{
+  ++elementSystemIndex;
+  ++phaseSystemIndex;
+  TCAPI_getElementMolesInPhaseByIndex(&elementSystemIndex, &phaseSystemIndex, molesElement, info);
 }
 
 void GetElementMoleFractionInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
@@ -84,6 +98,24 @@ void GetPureConPhaseMol(const char *phaseName, double *molesPhase, int *info)
 void GetPhaseIndex(const char *phaseName, int *index, int *info)
 {
   TCAPI_getPhaseIndex(phaseName, strlen(phaseName), index, info);
+}
+
+void GetPhaseIndexBySystemIndex(int phaseSystemIndex, int *index, int *info)
+{
+  ++phaseSystemIndex;
+  TCAPI_getPhaseIndexBySystemIndex(&phaseSystemIndex, index, info);
+}
+
+void GetPhaseMolesBySystemIndex(int phaseSystemIndex, double *moles, int *info)
+{
+  ++phaseSystemIndex;
+  TCAPI_getPhaseMolesBySystemIndex(&phaseSystemIndex, moles, info);
+}
+
+void GetElementIndexByAtomicNumber(int atomicNumber, int *index, int *info)
+{
+  TCAPI_getElementIndexByAtomicNumber(&atomicNumber, index, info);
+  --*index;
 }
 
 void GetOutputSiteFraction(const char *phaseName, int *sublattice, int *constituent, double *siteFraction, int *info)
@@ -121,11 +153,10 @@ struct cmp_str
   }
 };
 
-unsigned int
-atomicNumber(const char *element)
+unsigned int atomicNumber(const char *element)
 {
-  static std::map<const char *, unsigned int, cmp_str> _atomic_number_map = {
-      {"H", 1}, {"He", 2}, {"Li", 3}, {"Be", 4}, {"B", 5}, {"C", 6}, {"N", 7}, {"O", 8}, {"F", 9}, {"Ne", 10}, {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15}, {"S", 16}, {"Cl", 17}, {"Ar", 18}, {"K", 19}, {"Ca", 20}, {"Sc", 21}, {"Ti", 22}, {"V", 23}, {"Cr", 24}, {"Mn", 25}, {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30}, {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35}, {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39}, {"Zr", 40}, {"Nb", 41}, {"Mo", 42}, {"Tc", 43}, {"Ru", 44}, {"Rh", 45}, {"Pd", 46}, {"Ag", 47}, {"Cd", 48}, {"In", 49}, {"Sn", 50}, {"Sb", 51}, {"Te", 52}, {"I", 53}, {"Xe", 54}, {"Cs", 55}, {"Ba", 56}, {"La", 57}, {"Ce", 58}, {"Pr", 59}, {"Nd", 60}, {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65}, {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70}, {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75}, {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80}, {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85}, {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90}, {"Pa", 91}, {"U", 92}, {"Np", 93}, {"Pu", 94}, {"Am", 95}, {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100}, {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105}, {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110}, {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115}, {"Lv", 116}, {"Ts", 117}, {"Og", 118}};
+  static std::map<const char *, unsigned int, cmp_str> _atomic_number_map = {{"H", 1},   {"He", 2},  {"Li", 3},  {"Be", 4},  {"B", 5},   {"C", 6},   {"N", 7},   {"O", 8},   {"F", 9},   {"Ne", 10}, {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15}, {"S", 16},  {"Cl", 17}, {"Ar", 18}, {"K", 19},  {"Ca", 20}, {"Sc", 21}, {"Ti", 22}, {"V", 23},  {"Cr", 24}, {"Mn", 25}, {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30}, {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35}, {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39},  {"Zr", 40}, {"Nb", 41},  {"Mo", 42},  {"Tc", 43},  {"Ru", 44},  {"Rh", 45},  {"Pd", 46},  {"Ag", 47},  {"Cd", 48},  {"In", 49},  {"Sn", 50},  {"Sb", 51},  {"Te", 52},  {"I", 53},   {"Xe", 54},  {"Cs", 55},  {"Ba", 56},  {"La", 57},  {"Ce", 58},  {"Pr", 59},
+                                                                             {"Nd", 60}, {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65}, {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70}, {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75}, {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80}, {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85}, {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90}, {"Pa", 91}, {"U", 92},  {"Np", 93}, {"Pu", 94}, {"Am", 95}, {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100}, {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105}, {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110}, {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115}, {"Lv", 116}, {"Ts", 117}, {"Og", 118}};
 
   auto it = _atomic_number_map.find(element);
   if (it != _atomic_number_map.end())

--- a/src/Thermochimica-c.h
+++ b/src/Thermochimica-c.h
@@ -10,12 +10,17 @@ void GetOutputChemPot(char *, double *, int *);
 void GetOutputSolnSpecies(const char *, char *, double *, double *, int *);
 void GetOutputMolSpecies(const char *, double *, double *, int *);
 void GetOutputMolSpeciesPhase(const char *, const char *, double *, int *);
+void GetOutputMolSpeciesPhaseByIndex(int, int, double *, int *);
 void GetElementMolesInPhase(const char *, const char *, double *, int *);
+void GetElementMolesInPhaseByIndex(int, int, double *, int *);
 void GetElementMoleFractionInPhase(const char *, const char *, double *, int *);
 
 void GetSolnPhaseMol(const char *, double *, int *);
 void GetPureConPhaseMol(const char *, double *, int *);
 void GetPhaseIndex(const char *, int *, int *);
+void GetPhaseIndexBySystemIndex(int, int *, int *);
+void GetPhaseMolesBySystemIndex(int, double *, int *);
+void GetElementIndexByAtomicNumber(int, int *, int *);
 
 void GetOutputSiteFraction(const char *, int *, int *, double *, int *);
 void GetSublSiteMol(const char *, int *, int *, double *, int *);

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -317,8 +317,7 @@ namespace Thermochimica
 
   // Data extraction APIs
 
-  std::pair<double, int>
-  getOutputChemPot(const std::string &elementName)
+  std::pair<double, int> getOutputChemPot(const std::string &elementName)
   {
     double chemPot;
     int info;
@@ -326,8 +325,7 @@ namespace Thermochimica
     return {chemPot, info};
   }
 
-  std::tuple<double, double, int>
-  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName)
+  std::tuple<double, double, int> getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName)
   {
     double moleFrac, chemPot;
     int info;
@@ -335,8 +333,7 @@ namespace Thermochimica
     return std::make_tuple(moleFrac, chemPot, info);
   }
 
-  std::tuple<double, double, int>
-  getOutputMolSpecies(const std::string &speciesName)
+  std::tuple<double, double, int> getOutputMolSpecies(const std::string &speciesName)
   {
     double moleFrac, moles;
     int info;
@@ -344,8 +341,7 @@ namespace Thermochimica
     return std::make_tuple(moleFrac, moles, info);
   }
 
-  std::pair<double, int>
-  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName)
+  std::pair<double, int> getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName)
   {
     double moleFrac;
     int info;
@@ -353,8 +349,17 @@ namespace Thermochimica
     return {moleFrac, info};
   }
 
-  std::pair<double, int>
-  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName)
+  std::pair<double, int> getOutputMolSpeciesPhase(int phaseSystemIndex, int speciesPhaseIndex)
+  {
+    double moleFrac;
+    int info;
+    auto fortran_phase_index = phaseSystemIndex + 1;
+    auto fortran_species_index = speciesPhaseIndex + 1;
+    TCAPI_getOutputMolSpeciesPhaseByIndex(&fortran_phase_index, &fortran_species_index, &moleFrac, &info);
+    return {moleFrac, info};
+  }
+
+  std::pair<double, int> getElementMolesInPhase(const std::string &elementName, const std::string &phaseName)
   {
     double molesElement;
     int info;
@@ -362,8 +367,17 @@ namespace Thermochimica
     return {molesElement, info};
   }
 
-  std::pair<double, int>
-  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName)
+  std::pair<double, int> getElementMolesInPhase(int elementSystemIndex, int phaseSystemIndex)
+  {
+    double molesElement;
+    int info;
+    auto fortran_element_index = elementSystemIndex + 1;
+    auto fortran_phase_index = phaseSystemIndex + 1;
+    TCAPI_getElementMolesInPhaseByIndex(&fortran_element_index, &fortran_phase_index, &molesElement, &info);
+    return {molesElement, info};
+  }
+
+  std::pair<double, int> getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName)
   {
     double moleFracElement;
     int info;
@@ -371,8 +385,7 @@ namespace Thermochimica
     return {moleFracElement, info};
   }
 
-  std::pair<double, int>
-  getSolnPhaseMol(const std::string &phaseName)
+  std::pair<double, int> getSolnPhaseMol(const std::string &phaseName)
   {
     double molesPhase;
     int info;
@@ -380,8 +393,7 @@ namespace Thermochimica
     return {molesPhase, info};
   }
 
-  std::pair<double, int>
-  getPureConPhaseMol(const std::string &phaseName)
+  std::pair<double, int> getPureConPhaseMol(const std::string &phaseName)
   {
     double molesPhase;
     int info;
@@ -389,16 +401,47 @@ namespace Thermochimica
     return {molesPhase, info};
   }
 
-  std::pair<int, int>
-  getPhaseIndex(const std::string &phaseName)
+  std::pair<int, int> getPhaseIndex(const std::string &phaseName)
   {
     int index, info;
     TCAPI_getPhaseIndex(phaseName.c_str(), phaseName.length(), &index, &info);
     return {index, info};
   }
 
-  std::pair<double, int>
-  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent)
+  std::pair<int, int> getPhaseIndex(int phaseSystemIndex)
+  {
+    int index, info;
+    auto fortran_index = phaseSystemIndex + 1;
+    TCAPI_getPhaseIndexBySystemIndex(&fortran_index, &index, &info);
+    return {index, info};
+  }
+
+  std::pair<double, int> getPhaseMoles(int phaseSystemIndex)
+  {
+    double moles;
+    int info;
+    auto fortran_index = phaseSystemIndex + 1;
+    TCAPI_getPhaseMolesBySystemIndex(&fortran_index, &moles, &info);
+    return {moles, info};
+  }
+
+  std::pair<int, int> getElementIndex(int atomicNumber)
+  {
+    int index, info;
+    TCAPI_getElementIndexByAtomicNumber(&atomicNumber, &index, &info);
+    return {index - 1, info};
+  }
+
+  std::pair<double, int> getElementPotential(int elementSystemIndex)
+  {
+    double potential;
+    int info;
+    auto fortran_index = elementSystemIndex + 1;
+    TCAPI_getElementPotential(&fortran_index, &potential, &info);
+    return {potential, info};
+  }
+
+  std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent)
   {
     double siteFraction;
     int info;
@@ -406,8 +449,7 @@ namespace Thermochimica
     return {siteFraction, info};
   }
 
-  std::pair<double, int>
-  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent)
+  std::pair<double, int> getSublSiteMol(const std::string &phaseName, int sublattice, int constituent)
   {
     double siteMoles;
     int info;
@@ -435,8 +477,7 @@ namespace Thermochimica
     return isMQM;
   }
 
-  std::pair<double, int>
-  getMqmqaMolesPairs(const std::string &phaseName)
+  std::pair<double, int> getMqmqaMolesPairs(const std::string &phaseName)
   {
     double molesPairs;
     int info;
@@ -444,8 +485,7 @@ namespace Thermochimica
     return {molesPairs, info};
   }
 
-  std::pair<double, int>
-  getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName)
+  std::pair<double, int> getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName)
   {
     double molesPairs;
     int info;
@@ -453,8 +493,7 @@ namespace Thermochimica
     return {molesPairs, info};
   }
 
-  std::tuple<int, int, int>
-  getMqmqaNumberPairsQuads(const std::string &phaseName)
+  std::tuple<int, int, int> getMqmqaNumberPairsQuads(const std::string &phaseName)
   {
     int nPairs;
     int nQuads;
@@ -463,8 +502,7 @@ namespace Thermochimica
     return std::make_tuple(nPairs, nQuads, info);
   }
 
-  std::pair<double, int>
-  getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent)
+  std::pair<double, int> getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent)
   {
     double moleFraction;
     int info;
@@ -472,8 +510,7 @@ namespace Thermochimica
     return {moleFraction, info};
   }
 
-  ReinitializationData
-  getReinitData()
+  ReinitializationData getReinitData()
   {
     ReinitializationData data;
     int available, iterations;
@@ -484,14 +521,7 @@ namespace Thermochimica
     data.chemicalPotential.resize(species);
     data.moleFraction.resize(species);
 
-    TCAPI_getReinitData(data.assemblage.data(),
-                        data.molesPhase.data(),
-                        data.elementPotential.data(),
-                        data.chemicalPotential.data(),
-                        data.moleFraction.data(),
-                        data.elementsUsed.data(),
-                        &available,
-                        &iterations);
+    TCAPI_getReinitData(data.assemblage.data(), data.molesPhase.data(), data.elementPotential.data(), data.chemicalPotential.data(), data.moleFraction.data(), data.elementsUsed.data(), &available, &iterations);
 
     data.reinitAvailable = available;
     data.GEM_iterations = iterations;
@@ -499,11 +529,23 @@ namespace Thermochimica
     return data;
   }
 
-  void
-  setReinitData(const ReinitializationData & data)
+  void setReinitData(const ReinitializationData &data)
   {
     auto [elements, species] = getReinitDataSizes();
     TCAPI_setReinitData(&elements, &species, data.assemblage.data(), data.molesPhase.data(), data.elementPotential.data(), data.chemicalPotential.data(), data.moleFraction.data(), data.elementsUsed.data());
+  }
+
+  std::pair<bool, int> getReinitData(ReinitializationDataView data)
+  {
+    int available, iterations;
+    TCAPI_getReinitData(data.assemblage, data.molesPhase, data.elementPotential, data.chemicalPotential, data.moleFraction, data.elementsUsed, &available, &iterations);
+    return {available != 0, iterations};
+  }
+
+  void setReinitData(ReinitializationDataView data)
+  {
+    auto [elements, species] = getReinitDataSizes();
+    TCAPI_setReinitData(&elements, &species, data.assemblage, data.molesPhase, data.elementPotential, data.chemicalPotential, data.moleFraction, data.elementsUsed);
   }
 
   void setHeatCapacityEnthalpyEntropyRequested(bool requested)
@@ -545,4 +587,4 @@ namespace Thermochimica
     TCAPI_setMassBalanceTolerance(&tolerance);
   }
 
-}
+} // namespace Thermochimica

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -1,6 +1,8 @@
-#include <utility>
-#include <tuple>
 #include <string>
+#include <tuple>
+#pragma once
+
+#include <utility>
 #include <vector>
 
 // #include "checkUnits.h"
@@ -54,40 +56,31 @@ namespace Thermochimica
   std::vector<double> getAllElementPotential();
   double getElementFraction(int atomicNumber);
 
-  std::pair<double, int>
-  getOutputChemPot(const std::string &elementName);
-  std::tuple<double, double, int>
-  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName);
-  std::tuple<double, double, int>
-  getOutputMolSpecies(const std::string &speciesName);
-  std::pair<double, int>
-  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName);
-  std::pair<double, int>
-  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName);
-  std::pair<double, int>
-  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName);
-  std::pair<double, int>
-  getSolnPhaseMol(const std::string &phaseName);
-  std::pair<double, int>
-  getPureConPhaseMol(const std::string &phaseName);
-  std::pair<int, int>
-  getPhaseIndex(const std::string &phaseName);
-  std::pair<double, int>
-  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);
-  std::pair<double, int>
-  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent);
+  std::pair<double, int> getOutputChemPot(const std::string &elementName);
+  std::tuple<double, double, int> getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName);
+  std::tuple<double, double, int> getOutputMolSpecies(const std::string &speciesName);
+  std::pair<double, int> getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName);
+  std::pair<double, int> getOutputMolSpeciesPhase(int phaseSystemIndex, int speciesPhaseIndex);
+  std::pair<double, int> getElementMolesInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int> getElementMolesInPhase(int elementSystemIndex, int phaseSystemIndex);
+  std::pair<double, int> getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int> getSolnPhaseMol(const std::string &phaseName);
+  std::pair<double, int> getPureConPhaseMol(const std::string &phaseName);
+  std::pair<int, int> getPhaseIndex(const std::string &phaseName);
+  std::pair<int, int> getPhaseIndex(int phaseSystemIndex);
+  std::pair<double, int> getPhaseMoles(int phaseSystemIndex);
+  std::pair<int, int> getElementIndex(int atomicNumber);
+  std::pair<double, int> getElementPotential(int elementSystemIndex);
+  std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);
+  std::pair<double, int> getSublSiteMol(const std::string &phaseName, int sublattice, int constituent);
 
   bool isPhaseGas(const int phaseIndex);
 
   bool isPhaseMQM(const int phaseIndex);
-  std::pair<double, int>
-  getMqmqaMolesPairs(const std::string &phaseName);
-  std::pair<double, int>
-  getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName);
-  std::tuple<int, int, int>
-  getMqmqaNumberPairsQuads(const std::string &phaseName);
-  std::pair<double, int>
-  getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent);
+  std::pair<double, int> getMqmqaMolesPairs(const std::string &phaseName);
+  std::pair<double, int> getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName);
+  std::tuple<int, int, int> getMqmqaNumberPairsQuads(const std::string &phaseName);
+  std::pair<double, int> getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent);
 
   // Reinitialization data
   struct ReinitializationData
@@ -105,7 +98,20 @@ namespace Thermochimica
   };
 
   ReinitializationData getReinitData();
-  void setReinitData(const ReinitializationData & data);
+  void setReinitData(const ReinitializationData &data);
+
+  struct ReinitializationDataView
+  {
+    int *assemblage;
+    double *molesPhase;
+    double *elementPotential;
+    double *chemicalPotential;
+    double *moleFraction;
+    int *elementsUsed;
+  };
+
+  std::pair<bool, int> getReinitData(ReinitializationDataView data);
+  void setReinitData(ReinitializationDataView data);
 
   // Heat capacity, enthalpy, and entropy
   void setHeatCapacityEnthalpyEntropyRequested(bool requested);
@@ -118,4 +124,4 @@ namespace Thermochimica
   void setMinMoleFraction(double min_mole_fraction);
   void setMassBalanceTolerance(double tolerance);
 
-}
+} // namespace Thermochimica

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -19,12 +19,17 @@ extern "C"
   void TCAPI_getOutputSolnSpecies(const char *, std::size_t, const char *, std::size_t, double *, double *, int *);
   void TCAPI_getOutputMolSpecies(const char *, std::size_t, double *, double *, int *);
   void TCAPI_getOutputMolSpeciesPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getOutputMolSpeciesPhaseByIndex(const int *, const int *, double *, int *);
   void TCAPI_getElementMolesInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getElementMolesInPhaseByIndex(const int *, const int *, double *, int *);
   void TCAPI_getElementMoleFractionInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
 
   void TCAPI_getSolnPhaseMol(const char *, std::size_t, double *, int *);
   void TCAPI_getPureConPhaseMol(const char *, std::size_t, double *, int *);
   void TCAPI_getPhaseIndex(const char *, std::size_t, int *, int *);
+  void TCAPI_getPhaseIndexBySystemIndex(const int *, int *, int *);
+  void TCAPI_getPhaseMolesBySystemIndex(const int *, double *, int *);
+  void TCAPI_getElementIndexByAtomicNumber(const int *, int *, int *);
 
   void TCAPI_getOutputSiteFraction(const char *, std::size_t, int *, int *, double *, int *);
   void TCAPI_getSublSiteMol(const char *, std::size_t, int *, int *, double *, int *);

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -897,6 +897,107 @@ subroutine GetOutputMolSpeciesPhaseISO(cPhase, lcPhase, cSpecies, lcSpecies, dMo
 
 end subroutine GetOutputMolSpeciesPhaseISO
 
+subroutine GetOutputMolSpeciesPhaseByIndexISO(iPhaseSystem, iSpeciesPhase, dMolFractionOut, INFO) &
+    bind(C, name="TCAPI_getOutputMolSpeciesPhaseByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolFraction, iAssemblage, nElements, &
+                            nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)    :: iPhaseSystem, iSpeciesPhase
+    real(C_DOUBLE), intent(out)   :: dMolFractionOut
+    integer(C_INT), intent(out)   :: INFO
+    integer(C_INT)                :: i, iActualPhase, iActualSpecies
+
+    INFO = 0
+    dMolFractionOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys .OR. iSpeciesPhase <= 0 .OR. &
+        iSpeciesPhase > nSpeciesPhase(iPhaseSystem) - nSpeciesPhase(iPhaseSystem - 1)) then
+        INFO = 2
+        return
+    end if
+
+    do i = 1, nElements
+        if (iAssemblage(i) < 0) then
+            if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                iActualPhase = -iAssemblage(i)
+                iActualSpecies = nSpeciesPhase(iActualPhase - 1) + iSpeciesPhase
+                dMolFractionOut = dMolFraction(iActualSpecies)
+                return
+            end if
+        end if
+    end do
+
+    INFO = 1
+
+end subroutine GetOutputMolSpeciesPhaseByIndexISO
+
+subroutine GetElementMolesInPhaseByIndexISO(iElementSystem, iPhaseSystem, dMolesOut, INFO) &
+    bind(C, name="TCAPI_getElementMolesInPhaseByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolesPhase, dMolesSpecies, dStoichSpecies, &
+                            iAssemblage, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iElementSystem, iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dMolesOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iActualPhase, iTarget, j
+
+    INFO = 0
+    dMolesOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iElementSystem <= 0 .OR. iElementSystem > nElements) then
+        INFO = 1
+        return
+    end if
+    if (iPhaseSystem <= 0) then
+        INFO = 2
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    iActualPhase = -iAssemblage(i)
+                    do j = nSpeciesPhase(iActualPhase - 1) + 1, nSpeciesPhase(iActualPhase)
+                        dMolesOut = dMolesOut + dMolesSpecies(j) * dStoichSpecies(j, iElementSystem)
+                    end do
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                dMolesOut = dMolesPhase(i) * dStoichSpecies(iTarget, iElementSystem)
+                return
+            end if
+        end do
+    end if
+
+    INFO = 2
+
+end subroutine GetElementMolesInPhaseByIndexISO
+
 subroutine GetOutputSiteFractionISO(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, dSiteFractionOut, INFO) &
     bind(C, name="TCAPI_getOutputSiteFraction")
 
@@ -955,11 +1056,137 @@ subroutine GetPhaseIndexISO(cPhaseName, lcPhaseName, iIndexOut, INFO) &
 
     call c_f_pointer(cptr=c_loc(cPhaseName), fptr=fPhaseName)
 
-    call GetPhaseIndex(cPhaseName, lcPhaseName, iIndexOut, INFO)
+    call GetPhaseIndex(fPhaseName, lcPhaseName, iIndexOut, INFO)
 
     return
 
 end subroutine GetPhaseIndexISO
+
+subroutine GetPhaseIndexBySystemIndexISO(iPhaseSystem, iIndexOut, INFO) &
+    bind(C, name="TCAPI_getPhaseIndexBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, iAssemblage, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    integer(C_INT), intent(out) :: iIndexOut, INFO
+    integer(C_INT)              :: i, iTarget
+
+    INFO = 0
+    iIndexOut = 0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    if (iPhaseSystem <= 0) then
+        INFO = 1
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    iIndexOut = i
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                iIndexOut = i
+                return
+            end if
+        end do
+    end if
+
+end subroutine GetPhaseIndexBySystemIndexISO
+
+subroutine GetPhaseMolesBySystemIndexISO(iPhaseSystem, dMolesOut, INFO) &
+    bind(C, name="TCAPI_getPhaseMolesBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolesPhase, iAssemblage, nElements, &
+                            nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dMolesOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iTarget
+
+    INFO = 0
+    dMolesOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0) then
+        INFO = 1
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    dMolesOut = dMolesPhase(i)
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                dMolesOut = dMolesPhase(i)
+                return
+            end if
+        end do
+    end if
+
+end subroutine GetPhaseMolesBySystemIndexISO
+
+subroutine GetElementIndexByAtomicNumberISO(iAtomicNumber, iIndexOut, INFO) &
+    bind(C, name="TCAPI_getElementIndexByAtomicNumber")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: iElementSystem
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iAtomicNumber
+    integer(C_INT), intent(out) :: iIndexOut, INFO
+    integer(C_INT)              :: i
+
+    INFO = 0
+    iIndexOut = 0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    do i = 1, SIZE(iElementSystem)
+        if (iElementSystem(i) /= 0) iIndexOut = iIndexOut + 1
+        if (iElementSystem(i) == iAtomicNumber) return
+    end do
+
+    iIndexOut = 0
+    INFO = 1
+
+end subroutine GetElementIndexByAtomicNumberISO
 
 subroutine GetPureConPhaseMolISO(cPureConOut, lcPureConOut, dPureConMolOut, INFO) &
     bind(C, name="TCAPI_getPureConPhaseMol")


### PR DESCRIPTION
## Summary

- add indexed C and C++ result-query APIs for phases, solution species, elements, and element-in-phase amounts
- add non-owning reinitialization-data views so callers can reuse packed storage without allocating and copying vectors for every solve
- retain the existing string-based APIs while allowing callers to resolve names once during setup
- correct the ISO C phase-index wrapper to forward the complete phase name

## Motivation

High-throughput couplings such as MOOSE evaluate many independent equilibrium states. Repeating phase, species, and element name resolution inside every solve adds avoidable string lookup and allocation overhead. These APIs allow a coupling layer to validate metadata once and use typed integer handles in its hot loop.

The reinitialization view overloads similarly allow per-location warm-start data to be stored in caller-owned contiguous buffers.

## Impact

This is additive API functionality. Existing string-based queries and owning reinitialization-data methods remain available.

## Validation

- `make test` completed successfully when run serially
- `./run_tests` passed all Thermochimica daily tests
- indexed queries were compared against the existing string-based APIs in the downstream MOOSE integration
- the downstream MOOSE Chemical Reactions Thermochimica suite passed 32/32 tests
