### PR TITLE
Add indexed thermodynamic result APIs

### DIFF
--- a/src/Thermochimica-c.C
+++ b/src/Thermochimica-c.C
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <math.h>
+#include "Thermochimica.h"
 #include <cstring>
 #include <map>
-#include "Thermochimica.h"
+#include <math.h>
+#include <stdio.h>
 
 void SetThermoFilename(const char *filename)
 {
@@ -61,9 +61,23 @@ void GetOutputMolSpeciesPhase(const char *phaseName, const char *speciesName, do
   TCAPI_getOutputMolSpeciesPhase(phaseName, strlen(phaseName), speciesName, strlen(speciesName), moleFraction, info);
 }
 
+void GetOutputMolSpeciesPhaseByIndex(int phaseSystemIndex, int speciesSystemIndex, double *moleFraction, int *info)
+{
+  ++phaseSystemIndex;
+  ++speciesSystemIndex;
+  TCAPI_getOutputMolSpeciesPhaseByIndex(&phaseSystemIndex, &speciesSystemIndex, moleFraction, info);
+}
+
 void GetElementMolesInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
 {
   TCAPI_getElementMolesInPhase(elementName, strlen(elementName), phaseName, strlen(phaseName), molesElement, info);
+}
+
+void GetElementMolesInPhaseByIndex(int elementSystemIndex, int phaseSystemIndex, double *molesElement, int *info)
+{
+  ++elementSystemIndex;
+  ++phaseSystemIndex;
+  TCAPI_getElementMolesInPhaseByIndex(&elementSystemIndex, &phaseSystemIndex, molesElement, info);
 }
 
 void GetElementMoleFractionInPhase(const char *elementName, const char *phaseName, double *molesElement, int *info)
@@ -84,6 +98,24 @@ void GetPureConPhaseMol(const char *phaseName, double *molesPhase, int *info)
 void GetPhaseIndex(const char *phaseName, int *index, int *info)
 {
   TCAPI_getPhaseIndex(phaseName, strlen(phaseName), index, info);
+}
+
+void GetPhaseIndexBySystemIndex(int phaseSystemIndex, int *index, int *info)
+{
+  ++phaseSystemIndex;
+  TCAPI_getPhaseIndexBySystemIndex(&phaseSystemIndex, index, info);
+}
+
+void GetPhaseMolesBySystemIndex(int phaseSystemIndex, double *moles, int *info)
+{
+  ++phaseSystemIndex;
+  TCAPI_getPhaseMolesBySystemIndex(&phaseSystemIndex, moles, info);
+}
+
+void GetElementIndexByAtomicNumber(int atomicNumber, int *index, int *info)
+{
+  TCAPI_getElementIndexByAtomicNumber(&atomicNumber, index, info);
+  --*index;
 }
 
 void GetOutputSiteFraction(const char *phaseName, int *sublattice, int *constituent, double *siteFraction, int *info)
@@ -121,11 +153,10 @@ struct cmp_str
   }
 };
 
-unsigned int
-atomicNumber(const char *element)
+unsigned int atomicNumber(const char *element)
 {
-  static std::map<const char *, unsigned int, cmp_str> _atomic_number_map = {
-      {"H", 1}, {"He", 2}, {"Li", 3}, {"Be", 4}, {"B", 5}, {"C", 6}, {"N", 7}, {"O", 8}, {"F", 9}, {"Ne", 10}, {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15}, {"S", 16}, {"Cl", 17}, {"Ar", 18}, {"K", 19}, {"Ca", 20}, {"Sc", 21}, {"Ti", 22}, {"V", 23}, {"Cr", 24}, {"Mn", 25}, {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30}, {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35}, {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39}, {"Zr", 40}, {"Nb", 41}, {"Mo", 42}, {"Tc", 43}, {"Ru", 44}, {"Rh", 45}, {"Pd", 46}, {"Ag", 47}, {"Cd", 48}, {"In", 49}, {"Sn", 50}, {"Sb", 51}, {"Te", 52}, {"I", 53}, {"Xe", 54}, {"Cs", 55}, {"Ba", 56}, {"La", 57}, {"Ce", 58}, {"Pr", 59}, {"Nd", 60}, {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65}, {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70}, {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75}, {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80}, {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85}, {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90}, {"Pa", 91}, {"U", 92}, {"Np", 93}, {"Pu", 94}, {"Am", 95}, {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100}, {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105}, {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110}, {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115}, {"Lv", 116}, {"Ts", 117}, {"Og", 118}};
+  static std::map<const char *, unsigned int, cmp_str> _atomic_number_map = {{"H", 1},   {"He", 2},  {"Li", 3},  {"Be", 4},  {"B", 5},   {"C", 6},   {"N", 7},   {"O", 8},   {"F", 9},   {"Ne", 10}, {"Na", 11}, {"Mg", 12}, {"Al", 13}, {"Si", 14}, {"P", 15}, {"S", 16},  {"Cl", 17}, {"Ar", 18}, {"K", 19},  {"Ca", 20}, {"Sc", 21}, {"Ti", 22}, {"V", 23},  {"Cr", 24}, {"Mn", 25}, {"Fe", 26}, {"Co", 27}, {"Ni", 28}, {"Cu", 29}, {"Zn", 30}, {"Ga", 31}, {"Ge", 32}, {"As", 33}, {"Se", 34}, {"Br", 35}, {"Kr", 36}, {"Rb", 37}, {"Sr", 38}, {"Y", 39},  {"Zr", 40}, {"Nb", 41},  {"Mo", 42},  {"Tc", 43},  {"Ru", 44},  {"Rh", 45},  {"Pd", 46},  {"Ag", 47},  {"Cd", 48},  {"In", 49},  {"Sn", 50},  {"Sb", 51},  {"Te", 52},  {"I", 53},   {"Xe", 54},  {"Cs", 55},  {"Ba", 56},  {"La", 57},  {"Ce", 58},  {"Pr", 59},
+                                                                             {"Nd", 60}, {"Pm", 61}, {"Sm", 62}, {"Eu", 63}, {"Gd", 64}, {"Tb", 65}, {"Dy", 66}, {"Ho", 67}, {"Er", 68}, {"Tm", 69}, {"Yb", 70}, {"Lu", 71}, {"Hf", 72}, {"Ta", 73}, {"W", 74}, {"Re", 75}, {"Os", 76}, {"Ir", 77}, {"Pt", 78}, {"Au", 79}, {"Hg", 80}, {"Tl", 81}, {"Pb", 82}, {"Bi", 83}, {"Po", 84}, {"At", 85}, {"Rn", 86}, {"Fr", 87}, {"Ra", 88}, {"Ac", 89}, {"Th", 90}, {"Pa", 91}, {"U", 92},  {"Np", 93}, {"Pu", 94}, {"Am", 95}, {"Cm", 96}, {"Bk", 97}, {"Cf", 98}, {"Es", 99}, {"Fm", 100}, {"Md", 101}, {"No", 102}, {"Lr", 103}, {"Rf", 104}, {"Db", 105}, {"Sg", 106}, {"Bh", 107}, {"Hs", 108}, {"Mt", 109}, {"Ds", 110}, {"Rg", 111}, {"Cn", 112}, {"Nh", 113}, {"Fl", 114}, {"Mc", 115}, {"Lv", 116}, {"Ts", 117}, {"Og", 118}};
 
   auto it = _atomic_number_map.find(element);
   if (it != _atomic_number_map.end())

--- a/src/Thermochimica-c.h
+++ b/src/Thermochimica-c.h
@@ -10,12 +10,17 @@ void GetOutputChemPot(char *, double *, int *);
 void GetOutputSolnSpecies(const char *, char *, double *, double *, int *);
 void GetOutputMolSpecies(const char *, double *, double *, int *);
 void GetOutputMolSpeciesPhase(const char *, const char *, double *, int *);
+void GetOutputMolSpeciesPhaseByIndex(int, int, double *, int *);
 void GetElementMolesInPhase(const char *, const char *, double *, int *);
+void GetElementMolesInPhaseByIndex(int, int, double *, int *);
 void GetElementMoleFractionInPhase(const char *, const char *, double *, int *);
 
 void GetSolnPhaseMol(const char *, double *, int *);
 void GetPureConPhaseMol(const char *, double *, int *);
 void GetPhaseIndex(const char *, int *, int *);
+void GetPhaseIndexBySystemIndex(int, int *, int *);
+void GetPhaseMolesBySystemIndex(int, double *, int *);
+void GetElementIndexByAtomicNumber(int, int *, int *);
 
 void GetOutputSiteFraction(const char *, int *, int *, double *, int *);
 void GetSublSiteMol(const char *, int *, int *, double *, int *);

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -521,6 +521,56 @@ namespace Thermochimica
     return {gibbs_energy, info};
   }
 
+  std::vector<std::vector<std::string>> getConstituentsInPhase(int phaseSystemIndex)
+  {
+    const auto fortran_phase = phaseSystemIndex + 1;
+    int number_sublattices = 0;
+    int status = 0;
+    TCAPI_getNumberSublattices(&fortran_phase, &number_sublattices, &status);
+    if (status != 0)
+      return {};
+
+    std::vector<std::vector<std::string>> constituents(number_sublattices);
+    for (int sublattice = 0; sublattice < number_sublattices; ++sublattice)
+    {
+      const auto fortran_sublattice = sublattice + 1;
+      int number_constituents = 0;
+      TCAPI_getNumberConstituents(
+          &fortran_phase, &fortran_sublattice, &number_constituents, &status);
+      if (status != 0)
+        return {};
+      constituents[sublattice].reserve(number_constituents);
+      for (int constituent = 0; constituent < number_constituents; ++constituent)
+      {
+        const auto fortran_constituent = constituent + 1;
+        int length = 0;
+        auto * name = TCAPI_getConstituentNameAtIndex(&fortran_phase,
+                                                      &fortran_sublattice,
+                                                      &fortran_constituent,
+                                                      &length,
+                                                      &status);
+        if (status != 0)
+          return {};
+        constituents[sublattice].emplace_back(name, name + length);
+      }
+    }
+    return constituents;
+  }
+
+  std::pair<double, int> getConstituentFraction(const int phaseSystemIndex,
+                                                const int sublatticeIndex,
+                                                const int constituentIndex)
+  {
+    const auto fortran_phase = phaseSystemIndex + 1;
+    const auto fortran_sublattice = sublatticeIndex + 1;
+    const auto fortran_constituent = constituentIndex + 1;
+    double value = 0.0;
+    int status = 0;
+    TCAPI_getConstituentFractionByIndex(
+        &fortran_phase, &fortran_sublattice, &fortran_constituent, &value, &status);
+    return {value, status};
+  }
+
   std::pair<int, int> getElementIndex(int atomicNumber)
   {
     int index, info;

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -317,8 +317,7 @@ namespace Thermochimica
 
   // Data extraction APIs
 
-  std::pair<double, int>
-  getOutputChemPot(const std::string &elementName)
+  std::pair<double, int> getOutputChemPot(const std::string &elementName)
   {
     double chemPot;
     int info;
@@ -326,8 +325,7 @@ namespace Thermochimica
     return {chemPot, info};
   }
 
-  std::tuple<double, double, int>
-  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName)
+  std::tuple<double, double, int> getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName)
   {
     double moleFrac, chemPot;
     int info;
@@ -335,8 +333,7 @@ namespace Thermochimica
     return std::make_tuple(moleFrac, chemPot, info);
   }
 
-  std::tuple<double, double, int>
-  getOutputMolSpecies(const std::string &speciesName)
+  std::tuple<double, double, int> getOutputMolSpecies(const std::string &speciesName)
   {
     double moleFrac, moles;
     int info;
@@ -344,8 +341,7 @@ namespace Thermochimica
     return std::make_tuple(moleFrac, moles, info);
   }
 
-  std::pair<double, int>
-  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName)
+  std::pair<double, int> getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName)
   {
     double moleFrac;
     int info;
@@ -353,8 +349,17 @@ namespace Thermochimica
     return {moleFrac, info};
   }
 
-  std::pair<double, int>
-  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName)
+  std::pair<double, int> getOutputMolSpeciesPhase(int phaseSystemIndex, int speciesPhaseIndex)
+  {
+    double moleFrac;
+    int info;
+    auto fortran_phase_index = phaseSystemIndex + 1;
+    auto fortran_species_index = speciesPhaseIndex + 1;
+    TCAPI_getOutputMolSpeciesPhaseByIndex(&fortran_phase_index, &fortran_species_index, &moleFrac, &info);
+    return {moleFrac, info};
+  }
+
+  std::pair<double, int> getElementMolesInPhase(const std::string &elementName, const std::string &phaseName)
   {
     double molesElement;
     int info;
@@ -362,8 +367,17 @@ namespace Thermochimica
     return {molesElement, info};
   }
 
-  std::pair<double, int>
-  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName)
+  std::pair<double, int> getElementMolesInPhase(int elementSystemIndex, int phaseSystemIndex)
+  {
+    double molesElement;
+    int info;
+    auto fortran_element_index = elementSystemIndex + 1;
+    auto fortran_phase_index = phaseSystemIndex + 1;
+    TCAPI_getElementMolesInPhaseByIndex(&fortran_element_index, &fortran_phase_index, &molesElement, &info);
+    return {molesElement, info};
+  }
+
+  std::pair<double, int> getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName)
   {
     double moleFracElement;
     int info;
@@ -371,8 +385,7 @@ namespace Thermochimica
     return {moleFracElement, info};
   }
 
-  std::pair<double, int>
-  getSolnPhaseMol(const std::string &phaseName)
+  std::pair<double, int> getSolnPhaseMol(const std::string &phaseName)
   {
     double molesPhase;
     int info;
@@ -380,8 +393,7 @@ namespace Thermochimica
     return {molesPhase, info};
   }
 
-  std::pair<double, int>
-  getPureConPhaseMol(const std::string &phaseName)
+  std::pair<double, int> getPureConPhaseMol(const std::string &phaseName)
   {
     double molesPhase;
     int info;
@@ -389,16 +401,47 @@ namespace Thermochimica
     return {molesPhase, info};
   }
 
-  std::pair<int, int>
-  getPhaseIndex(const std::string &phaseName)
+  std::pair<int, int> getPhaseIndex(const std::string &phaseName)
   {
     int index, info;
     TCAPI_getPhaseIndex(phaseName.c_str(), phaseName.length(), &index, &info);
     return {index, info};
   }
 
-  std::pair<double, int>
-  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent)
+  std::pair<int, int> getPhaseIndex(int phaseSystemIndex)
+  {
+    int index, info;
+    auto fortran_index = phaseSystemIndex + 1;
+    TCAPI_getPhaseIndexBySystemIndex(&fortran_index, &index, &info);
+    return {index, info};
+  }
+
+  std::pair<double, int> getPhaseMoles(int phaseSystemIndex)
+  {
+    double moles;
+    int info;
+    auto fortran_index = phaseSystemIndex + 1;
+    TCAPI_getPhaseMolesBySystemIndex(&fortran_index, &moles, &info);
+    return {moles, info};
+  }
+
+  std::pair<int, int> getElementIndex(int atomicNumber)
+  {
+    int index, info;
+    TCAPI_getElementIndexByAtomicNumber(&atomicNumber, &index, &info);
+    return {index - 1, info};
+  }
+
+  std::pair<double, int> getElementPotential(int elementSystemIndex)
+  {
+    double potential;
+    int info;
+    auto fortran_index = elementSystemIndex + 1;
+    TCAPI_getElementPotential(&fortran_index, &potential, &info);
+    return {potential, info};
+  }
+
+  std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent)
   {
     double siteFraction;
     int info;
@@ -406,8 +449,7 @@ namespace Thermochimica
     return {siteFraction, info};
   }
 
-  std::pair<double, int>
-  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent)
+  std::pair<double, int> getSublSiteMol(const std::string &phaseName, int sublattice, int constituent)
   {
     double siteMoles;
     int info;
@@ -435,8 +477,7 @@ namespace Thermochimica
     return isMQM;
   }
 
-  std::pair<double, int>
-  getMqmqaMolesPairs(const std::string &phaseName)
+  std::pair<double, int> getMqmqaMolesPairs(const std::string &phaseName)
   {
     double molesPairs;
     int info;
@@ -444,8 +485,7 @@ namespace Thermochimica
     return {molesPairs, info};
   }
 
-  std::pair<double, int>
-  getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName)
+  std::pair<double, int> getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName)
   {
     double molesPairs;
     int info;
@@ -453,8 +493,7 @@ namespace Thermochimica
     return {molesPairs, info};
   }
 
-  std::tuple<int, int, int>
-  getMqmqaNumberPairsQuads(const std::string &phaseName)
+  std::tuple<int, int, int> getMqmqaNumberPairsQuads(const std::string &phaseName)
   {
     int nPairs;
     int nQuads;
@@ -463,8 +502,7 @@ namespace Thermochimica
     return std::make_tuple(nPairs, nQuads, info);
   }
 
-  std::pair<double, int>
-  getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent)
+  std::pair<double, int> getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent)
   {
     double moleFraction;
     int info;
@@ -472,8 +510,7 @@ namespace Thermochimica
     return {moleFraction, info};
   }
 
-  ReinitializationData
-  getReinitData()
+  ReinitializationData getReinitData()
   {
     ReinitializationData data;
     int available, iterations;
@@ -484,14 +521,7 @@ namespace Thermochimica
     data.chemicalPotential.resize(species);
     data.moleFraction.resize(species);
 
-    TCAPI_getReinitData(data.assemblage.data(),
-                        data.molesPhase.data(),
-                        data.elementPotential.data(),
-                        data.chemicalPotential.data(),
-                        data.moleFraction.data(),
-                        data.elementsUsed.data(),
-                        &available,
-                        &iterations);
+    TCAPI_getReinitData(data.assemblage.data(), data.molesPhase.data(), data.elementPotential.data(), data.chemicalPotential.data(), data.moleFraction.data(), data.elementsUsed.data(), &available, &iterations);
 
     data.reinitAvailable = available;
     data.GEM_iterations = iterations;
@@ -499,11 +529,23 @@ namespace Thermochimica
     return data;
   }
 
-  void
-  setReinitData(const ReinitializationData & data)
+  void setReinitData(const ReinitializationData &data)
   {
     auto [elements, species] = getReinitDataSizes();
     TCAPI_setReinitData(&elements, &species, data.assemblage.data(), data.molesPhase.data(), data.elementPotential.data(), data.chemicalPotential.data(), data.moleFraction.data(), data.elementsUsed.data());
+  }
+
+  std::pair<bool, int> getReinitData(ReinitializationDataView data)
+  {
+    int available, iterations;
+    TCAPI_getReinitData(data.assemblage, data.molesPhase, data.elementPotential, data.chemicalPotential, data.moleFraction, data.elementsUsed, &available, &iterations);
+    return {available != 0, iterations};
+  }
+
+  void setReinitData(ReinitializationDataView data)
+  {
+    auto [elements, species] = getReinitDataSizes();
+    TCAPI_setReinitData(&elements, &species, data.assemblage, data.molesPhase, data.elementPotential, data.chemicalPotential, data.moleFraction, data.elementsUsed);
   }
 
   void setHeatCapacityEnthalpyEntropyRequested(bool requested)
@@ -545,4 +587,4 @@ namespace Thermochimica
     TCAPI_setMassBalanceTolerance(&tolerance);
   }
 
-}
+} // namespace Thermochimica

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -259,6 +259,25 @@ namespace Thermochimica
     return species;
   }
 
+  std::vector<std::string> getThermodynamicSpeciesInPhase(int phase_index)
+  {
+    const auto n_species = getNumberSpeciesSystem();
+    if (phase_index < 0 || phase_index >= static_cast<int>(n_species.size()))
+      return {};
+
+    const auto first = phase_index == 0 ? 0 : n_species[phase_index - 1];
+    const auto count = n_species[phase_index] - first;
+    std::vector<std::string> species(count);
+    for (std::size_t i = 0; i < count; ++i)
+    {
+      auto index = static_cast<int>(first + i + 1);
+      int length;
+      char *buffer = TCAPI_getSpeciesAtIndex(&index, &length);
+      species[i] = std::string(buffer, buffer + length);
+    }
+    return species;
+  }
+
   // re-initialization-related functions
   void saveReinitData()
   {
@@ -423,6 +442,51 @@ namespace Thermochimica
     auto fortran_index = phaseSystemIndex + 1;
     TCAPI_getPhaseMolesBySystemIndex(&fortran_index, &moles, &info);
     return {moles, info};
+  }
+
+  std::pair<double, int> getSpeciesChemicalPotential(int phaseSystemIndex, int speciesPhaseIndex)
+  {
+    double potential;
+    int info;
+    auto fortran_phase = phaseSystemIndex + 1;
+    auto fortran_species = speciesPhaseIndex + 1;
+    TCAPI_getSpeciesChemicalPotentialByIndex(&fortran_phase, &fortran_species, &potential, &info);
+    return {potential, info};
+  }
+
+  std::pair<double, int> getMqmqaEndmemberStoichiometricPotential(int phaseSystemIndex, int endmemberIndex)
+  {
+    double potential;
+    int info;
+    auto fortran_phase = phaseSystemIndex + 1;
+    auto fortran_endmember = endmemberIndex + 1;
+    TCAPI_getMqmqaEndmemberStoichiometricPotentialByIndex(&fortran_phase, &fortran_endmember, &potential, &info);
+    return {potential, info};
+  }
+
+  PhaseGibbsEnergy getPhaseGibbsEnergy(int phaseSystemIndex)
+  {
+    PhaseGibbsEnergy result;
+    auto fortran_phase = phaseSystemIndex + 1;
+    TCAPI_getPhaseGibbsEnergyBySystemIndex(&fortran_phase, &result.total, &result.molar, &result.status);
+    return result;
+  }
+
+  std::pair<double, int> getPhaseDrivingForce(int phaseSystemIndex)
+  {
+    double driving_force;
+    int info;
+    auto fortran_phase = phaseSystemIndex + 1;
+    TCAPI_getPhaseDrivingForceBySystemIndex(&fortran_phase, &driving_force, &info);
+    return {driving_force, info};
+  }
+
+  std::pair<double, int> getSystemGibbsEnergy()
+  {
+    double gibbs_energy;
+    int info;
+    TCAPI_getSystemGibbsEnergy(&gibbs_energy, &info);
+    return {gibbs_energy, info};
   }
 
   std::pair<int, int> getElementIndex(int atomicNumber)

--- a/src/Thermochimica-cxx.C
+++ b/src/Thermochimica-cxx.C
@@ -45,6 +45,38 @@ namespace Thermochimica
     TCAPI_setThermoFilename(filename.c_str(), filename.length());
   }
 
+  namespace
+  {
+    int setPhaseSelection(const std::vector<std::string> &phases, bool include)
+    {
+      if (phases.size() > 1000)
+        return 2;
+      for (const auto &phase : phases)
+        if (phase.empty() || phase.length() > 25)
+          return 1;
+
+      TCAPI_clearPhaseSelection();
+      for (const auto &phase : phases)
+      {
+        int status = 0;
+        TCAPI_addPhaseSelection(phase.c_str(), phase.length(), &include, &status);
+        if (status != 0)
+          return status;
+      }
+      return 0;
+    }
+  }
+
+  int setExcludedPhases(const std::vector<std::string> &phases)
+  {
+    return setPhaseSelection(phases, false);
+  }
+
+  int setIncludedPhases(const std::vector<std::string> &phases)
+  {
+    return setPhaseSelection(phases, true);
+  }
+
   void setUnitTemperature(const std::string &tunit)
   {
     TCAPI_setUnitTemperature(tunit.c_str(), tunit.length());

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -45,6 +45,7 @@ namespace Thermochimica
   std::vector<std::size_t> getNumberSpeciesSystem();
   std::vector<std::string> getSpeciesInPhase(int phase_index);
   std::vector<std::vector<std::string>> getSpeciesSystem();
+  std::vector<std::string> getThermodynamicSpeciesInPhase(int phase_index);
 
   // re-initialization-related functions
   void saveReinitData();
@@ -69,6 +70,17 @@ namespace Thermochimica
   std::pair<int, int> getPhaseIndex(const std::string &phaseName);
   std::pair<int, int> getPhaseIndex(int phaseSystemIndex);
   std::pair<double, int> getPhaseMoles(int phaseSystemIndex);
+  std::pair<double, int> getSpeciesChemicalPotential(int phaseSystemIndex, int speciesPhaseIndex);
+  std::pair<double, int> getMqmqaEndmemberStoichiometricPotential(int phaseSystemIndex, int endmemberIndex);
+  struct PhaseGibbsEnergy
+  {
+    double total;
+    double molar;
+    int status;
+  };
+  PhaseGibbsEnergy getPhaseGibbsEnergy(int phaseSystemIndex);
+  std::pair<double, int> getPhaseDrivingForce(int phaseSystemIndex);
+  std::pair<double, int> getSystemGibbsEnergy();
   std::pair<int, int> getElementIndex(int atomicNumber);
   std::pair<double, int> getElementPotential(int elementSystemIndex);
   std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -85,6 +85,12 @@ namespace Thermochimica
   PhaseGibbsEnergy getPhaseGibbsEnergy(int phaseSystemIndex);
   std::pair<double, int> getPhaseDrivingForce(int phaseSystemIndex);
   std::pair<double, int> getSystemGibbsEnergy();
+  /** Return constituent names by sublattice for a zero-based system phase index. */
+  std::vector<std::vector<std::string>> getConstituentsInPhase(int phaseSystemIndex);
+  /** Return a constituent fraction using zero-based phase, sublattice, and constituent indices. */
+  std::pair<double, int> getConstituentFraction(int phaseSystemIndex,
+                                                int sublatticeIndex,
+                                                int constituentIndex);
   std::pair<int, int> getElementIndex(int atomicNumber);
   std::pair<double, int> getElementPotential(int elementSystemIndex);
   std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -1,6 +1,8 @@
-#include <utility>
-#include <tuple>
 #include <string>
+#include <tuple>
+#pragma once
+
+#include <utility>
 #include <vector>
 
 // #include "checkUnits.h"
@@ -54,40 +56,31 @@ namespace Thermochimica
   std::vector<double> getAllElementPotential();
   double getElementFraction(int atomicNumber);
 
-  std::pair<double, int>
-  getOutputChemPot(const std::string &elementName);
-  std::tuple<double, double, int>
-  getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName);
-  std::tuple<double, double, int>
-  getOutputMolSpecies(const std::string &speciesName);
-  std::pair<double, int>
-  getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName);
-  std::pair<double, int>
-  getElementMolesInPhase(const std::string &elementName, const std::string &phaseName);
-  std::pair<double, int>
-  getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName);
-  std::pair<double, int>
-  getSolnPhaseMol(const std::string &phaseName);
-  std::pair<double, int>
-  getPureConPhaseMol(const std::string &phaseName);
-  std::pair<int, int>
-  getPhaseIndex(const std::string &phaseName);
-  std::pair<double, int>
-  getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);
-  std::pair<double, int>
-  getSublSiteMol(const std::string &phaseName, int sublattice, int constituent);
+  std::pair<double, int> getOutputChemPot(const std::string &elementName);
+  std::tuple<double, double, int> getOutputSolnSpecies(const std::string &phaseName, const std::string &speciesName);
+  std::tuple<double, double, int> getOutputMolSpecies(const std::string &speciesName);
+  std::pair<double, int> getOutputMolSpeciesPhase(const std::string &phaseName, const std::string &speciesName);
+  std::pair<double, int> getOutputMolSpeciesPhase(int phaseSystemIndex, int speciesPhaseIndex);
+  std::pair<double, int> getElementMolesInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int> getElementMolesInPhase(int elementSystemIndex, int phaseSystemIndex);
+  std::pair<double, int> getElementMoleFractionInPhase(const std::string &elementName, const std::string &phaseName);
+  std::pair<double, int> getSolnPhaseMol(const std::string &phaseName);
+  std::pair<double, int> getPureConPhaseMol(const std::string &phaseName);
+  std::pair<int, int> getPhaseIndex(const std::string &phaseName);
+  std::pair<int, int> getPhaseIndex(int phaseSystemIndex);
+  std::pair<double, int> getPhaseMoles(int phaseSystemIndex);
+  std::pair<int, int> getElementIndex(int atomicNumber);
+  std::pair<double, int> getElementPotential(int elementSystemIndex);
+  std::pair<double, int> getOutputSiteFraction(const std::string &phaseName, int sublattice, int constituent);
+  std::pair<double, int> getSublSiteMol(const std::string &phaseName, int sublattice, int constituent);
 
   bool isPhaseGas(const int phaseIndex);
 
   bool isPhaseMQM(const int phaseIndex);
-  std::pair<double, int>
-  getMqmqaMolesPairs(const std::string &phaseName);
-  std::pair<double, int>
-  getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName);
-  std::tuple<int, int, int>
-  getMqmqaNumberPairsQuads(const std::string &phaseName);
-  std::pair<double, int>
-  getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent);
+  std::pair<double, int> getMqmqaMolesPairs(const std::string &phaseName);
+  std::pair<double, int> getMqmqaPairMolFraction(const std::string &phaseName, const std::string &pairName);
+  std::tuple<int, int, int> getMqmqaNumberPairsQuads(const std::string &phaseName);
+  std::pair<double, int> getMqmqaConstituentFraction(const std::string &phaseName, int sublattice, const std::string &constituent);
 
   // Reinitialization data
   struct ReinitializationData
@@ -105,7 +98,20 @@ namespace Thermochimica
   };
 
   ReinitializationData getReinitData();
-  void setReinitData(const ReinitializationData & data);
+  void setReinitData(const ReinitializationData &data);
+
+  struct ReinitializationDataView
+  {
+    int *assemblage;
+    double *molesPhase;
+    double *elementPotential;
+    double *chemicalPotential;
+    double *moleFraction;
+    int *elementsUsed;
+  };
+
+  std::pair<bool, int> getReinitData(ReinitializationDataView data);
+  void setReinitData(ReinitializationDataView data);
 
   // Heat capacity, enthalpy, and entropy
   void setHeatCapacityEnthalpyEntropyRequested(bool requested);
@@ -118,4 +124,4 @@ namespace Thermochimica
   void setMinMoleFraction(double min_mole_fraction);
   void setMassBalanceTolerance(double tolerance);
 
-}
+} // namespace Thermochimica

--- a/src/Thermochimica-cxx.h
+++ b/src/Thermochimica-cxx.h
@@ -17,6 +17,10 @@ namespace Thermochimica
   void compThermoData();
 
   void setThermoFilename(const std::string &filename);
+  /** Exclude the named phases from subsequent equilibrium calculations; return zero on success. */
+  int setExcludedPhases(const std::vector<std::string> &phases);
+  /** Exclude every phase except the named phases; return zero on success. */
+  int setIncludedPhases(const std::vector<std::string> &phases);
   void setUnitTemperature(const std::string &tunit);
   void setUnitPressure(const std::string &punit);
   void setUnitMass(const std::string &munit);

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -29,6 +29,11 @@ extern "C"
   void TCAPI_getPhaseIndex(const char *, std::size_t, int *, int *);
   void TCAPI_getPhaseIndexBySystemIndex(const int *, int *, int *);
   void TCAPI_getPhaseMolesBySystemIndex(const int *, double *, int *);
+  void TCAPI_getSpeciesChemicalPotentialByIndex(const int *, const int *, double *, int *);
+  void TCAPI_getMqmqaEndmemberStoichiometricPotentialByIndex(const int *, const int *, double *, int *);
+  void TCAPI_getPhaseGibbsEnergyBySystemIndex(const int *, double *, double *, int *);
+  void TCAPI_getPhaseDrivingForceBySystemIndex(const int *, double *, int *);
+  void TCAPI_getSystemGibbsEnergy(double *, int *);
   void TCAPI_getElementIndexByAtomicNumber(const int *, int *, int *);
 
   void TCAPI_getOutputSiteFraction(const char *, std::size_t, int *, int *, double *, int *);

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -5,6 +5,8 @@
 extern "C"
 {
   void TCAPI_setThermoFilename(const char *, std::size_t);
+  void TCAPI_clearPhaseSelection();
+  void TCAPI_addPhaseSelection(const char *, std::size_t, bool *, int *);
   void TCAPI_setUnitTemperature(const char *, std::size_t);
   void TCAPI_setUnitPressure(const char *, std::size_t);
   void TCAPI_setUnitMass(const char *, std::size_t);

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -19,12 +19,17 @@ extern "C"
   void TCAPI_getOutputSolnSpecies(const char *, std::size_t, const char *, std::size_t, double *, double *, int *);
   void TCAPI_getOutputMolSpecies(const char *, std::size_t, double *, double *, int *);
   void TCAPI_getOutputMolSpeciesPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getOutputMolSpeciesPhaseByIndex(const int *, const int *, double *, int *);
   void TCAPI_getElementMolesInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
+  void TCAPI_getElementMolesInPhaseByIndex(const int *, const int *, double *, int *);
   void TCAPI_getElementMoleFractionInPhase(const char *, std::size_t, const char *, std::size_t, double *, int *);
 
   void TCAPI_getSolnPhaseMol(const char *, std::size_t, double *, int *);
   void TCAPI_getPureConPhaseMol(const char *, std::size_t, double *, int *);
   void TCAPI_getPhaseIndex(const char *, std::size_t, int *, int *);
+  void TCAPI_getPhaseIndexBySystemIndex(const int *, int *, int *);
+  void TCAPI_getPhaseMolesBySystemIndex(const int *, double *, int *);
+  void TCAPI_getElementIndexByAtomicNumber(const int *, int *, int *);
 
   void TCAPI_getOutputSiteFraction(const char *, std::size_t, int *, int *, double *, int *);
   void TCAPI_getSublSiteMol(const char *, std::size_t, int *, int *, double *, int *);

--- a/src/Thermochimica.h
+++ b/src/Thermochimica.h
@@ -37,6 +37,10 @@ extern "C"
   void TCAPI_getPhaseDrivingForceBySystemIndex(const int *, double *, int *);
   void TCAPI_getSystemGibbsEnergy(double *, int *);
   void TCAPI_getElementIndexByAtomicNumber(const int *, int *, int *);
+  void TCAPI_getNumberSublattices(const int *, int *, int *);
+  void TCAPI_getNumberConstituents(const int *, const int *, int *, int *);
+  char *TCAPI_getConstituentNameAtIndex(const int *, const int *, const int *, int *, int *);
+  void TCAPI_getConstituentFractionByIndex(const int *, const int *, const int *, double *, int *);
 
   void TCAPI_getOutputSiteFraction(const char *, std::size_t, int *, int *, double *, int *);
   void TCAPI_getSublSiteMol(const char *, std::size_t, int *, int *, double *, int *);

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -1157,6 +1157,225 @@ subroutine GetPhaseMolesBySystemIndexISO(iPhaseSystem, dMolesOut, INFO) &
 
 end subroutine GetPhaseMolesBySystemIndexISO
 
+subroutine GetSpeciesChemicalPotentialByIndexISO(iPhaseSystem, iSpeciesPhase, dPotentialOut, INFO) &
+    bind(C, name="TCAPI_getSpeciesChemicalPotentialByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleGEMSolver, ONLY: lSolnPhases
+    USE ModuleThermo, ONLY: dChemicalPotential, dIdealConstant, &
+                            nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: dTemperature, INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem, iSpeciesPhase
+    real(C_DOUBLE), intent(out) :: dPotentialOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: iSpecies
+
+    INFO = 0
+    dPotentialOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys .OR. iSpeciesPhase <= 0 .OR. &
+        iSpeciesPhase > nSpeciesPhase(iPhaseSystem) - nSpeciesPhase(iPhaseSystem - 1)) then
+        INFO = 2
+        return
+    end if
+    if (.NOT. lSolnPhases(iPhaseSystem)) then
+        INFO = 1
+        return
+    end if
+
+    iSpecies = nSpeciesPhase(iPhaseSystem - 1) + iSpeciesPhase
+    dPotentialOut = dChemicalPotential(iSpecies) * dIdealConstant * dTemperature
+
+end subroutine GetSpeciesChemicalPotentialByIndexISO
+
+subroutine GetMqmqaEndmemberStoichiometricPotentialByIndexISO(iPhaseSystem, iEndmember, dPotentialOut, INFO) &
+    bind(C, name="TCAPI_getMqmqaEndmemberStoichiometricPotentialByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseType, dElementPotential, dIdealConstant, dStoichPairs, &
+                            iPhaseSublattice, nElements, nPairsSRO, nSolnPhasesSys
+    USE ModuleThermoIO, ONLY: dTemperature, INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem, iEndmember
+    real(C_DOUBLE), intent(out) :: dPotentialOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iSublatticePhase
+
+    INFO = 0
+    dPotentialOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys) then
+        INFO = 2
+        return
+    end if
+    if (cSolnPhaseType(iPhaseSystem) /= 'SUBG' .AND. cSolnPhaseType(iPhaseSystem) /= 'SUBQ') then
+        INFO = 2
+        return
+    end if
+
+    iSublatticePhase = iPhaseSublattice(iPhaseSystem)
+    if (iEndmember <= 0 .OR. iEndmember > nPairsSRO(iSublatticePhase, 1)) then
+        INFO = 2
+        return
+    end if
+
+    do i = 1, nElements
+        dPotentialOut = dPotentialOut + dElementPotential(i) * dStoichPairs(iSublatticePhase, iEndmember, i)
+    end do
+    dPotentialOut = dPotentialOut * dIdealConstant * dTemperature
+
+end subroutine GetMqmqaEndmemberStoichiometricPotentialByIndexISO
+
+subroutine GetPhaseGibbsEnergyBySystemIndexISO(iPhaseSystem, dTotalOut, dMolarOut, INFO) &
+    bind(C, name="TCAPI_getPhaseGibbsEnergyBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: dChemicalPotential, dIdealConstant, dMolesPhase, dMolFraction, dStdGibbsEnergy, &
+                            iAssemblage, nConPhasesSys, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: dTemperature, INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dTotalOut, dMolarOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iFirst, iLast, iSpecies
+    real(C_DOUBLE)              :: dFractionSum
+
+    INFO = 0
+    dTotalOut = 0D0
+    dMolarOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys + nConPhasesSys) then
+        INFO = 2
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) == -iPhaseSystem) then
+                iFirst = nSpeciesPhase(iPhaseSystem - 1) + 1
+                iLast = nSpeciesPhase(iPhaseSystem)
+                dFractionSum = SUM(dMolFraction(iFirst:iLast))
+                if (dFractionSum <= 0D0) then
+                    INFO = 1
+                    return
+                end if
+                dMolarOut = SUM(dChemicalPotential(iFirst:iLast) * dMolFraction(iFirst:iLast)) / dFractionSum
+                dMolarOut = dMolarOut * dIdealConstant * dTemperature
+                dTotalOut = dMolarOut * dMolesPhase(i)
+                return
+            end if
+        end do
+    else
+        iSpecies = nSpeciesPhase(nSolnPhasesSys) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iSpecies) then
+                dMolarOut = dStdGibbsEnergy(iSpecies) * dIdealConstant * dTemperature
+                dTotalOut = dMolarOut * dMolesPhase(i)
+                return
+            end if
+        end do
+    end if
+
+    INFO = 1
+
+end subroutine GetPhaseGibbsEnergyBySystemIndexISO
+
+subroutine GetPhaseDrivingForceBySystemIndexISO(iPhaseSystem, dDrivingForceOut, INFO) &
+    bind(C, name="TCAPI_getPhaseDrivingForceBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: dChemicalPotential, dElementPotential, dIdealConstant, dMolFraction, &
+                            dSpeciesTotalAtoms, dStdGibbsEnergy, dStoichSpecies, &
+                            nConPhasesSys, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: dTemperature, INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dDrivingForceOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: iFirst, iLast, iSpecies
+    real(C_DOUBLE)              :: dAtomSum, dReferencePotential, dResidual
+
+    INFO = 0
+    dDrivingForceOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys + nConPhasesSys) then
+        INFO = 2
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        iFirst = nSpeciesPhase(iPhaseSystem - 1) + 1
+        iLast = nSpeciesPhase(iPhaseSystem)
+        dAtomSum = 0D0
+        dResidual = 0D0
+        do iSpecies = iFirst, iLast
+            if (dMolFraction(iSpecies) > 0D0) then
+                dReferencePotential = SUM(dElementPotential(1:nElements) * dStoichSpecies(iSpecies, 1:nElements))
+                dResidual = dResidual + dMolFraction(iSpecies) * &
+                            (dChemicalPotential(iSpecies) - dReferencePotential)
+                dAtomSum = dAtomSum + dMolFraction(iSpecies) * dSpeciesTotalAtoms(iSpecies)
+            end if
+        end do
+        if (dAtomSum <= 0D0) then
+            INFO = 1
+            return
+        end if
+        dDrivingForceOut = dResidual / dAtomSum
+    else
+        iSpecies = nSpeciesPhase(nSolnPhasesSys) + iPhaseSystem - nSolnPhasesSys
+        dReferencePotential = SUM(dElementPotential(1:nElements) * dStoichSpecies(iSpecies, 1:nElements))
+        dDrivingForceOut = (dStdGibbsEnergy(iSpecies) - dReferencePotential) / dSpeciesTotalAtoms(iSpecies)
+    end if
+
+    dDrivingForceOut = dDrivingForceOut * dIdealConstant * dTemperature
+
+end subroutine GetPhaseDrivingForceBySystemIndexISO
+
+subroutine GetSystemGibbsEnergyISO(dGibbsEnergyOut, INFO) bind(C, name="TCAPI_getSystemGibbsEnergy")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: dGibbsEnergySys, INFOThermo
+
+    implicit none
+
+    real(C_DOUBLE), intent(out) :: dGibbsEnergyOut
+    integer(C_INT), intent(out) :: INFO
+
+    INFO = 0
+    dGibbsEnergyOut = 0D0
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    dGibbsEnergyOut = dGibbsEnergySys
+
+end subroutine GetSystemGibbsEnergyISO
+
 subroutine GetElementIndexByAtomicNumberISO(iAtomicNumber, iIndexOut, INFO) &
     bind(C, name="TCAPI_getElementIndexByAtomicNumber")
 

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -897,6 +897,107 @@ subroutine GetOutputMolSpeciesPhaseISO(cPhase, lcPhase, cSpecies, lcSpecies, dMo
 
 end subroutine GetOutputMolSpeciesPhaseISO
 
+subroutine GetOutputMolSpeciesPhaseByIndexISO(iPhaseSystem, iSpeciesPhase, dMolFractionOut, INFO) &
+    bind(C, name="TCAPI_getOutputMolSpeciesPhaseByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolFraction, iAssemblage, nElements, &
+                            nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)    :: iPhaseSystem, iSpeciesPhase
+    real(C_DOUBLE), intent(out)   :: dMolFractionOut
+    integer(C_INT), intent(out)   :: INFO
+    integer(C_INT)                :: i, iActualPhase, iActualSpecies
+
+    INFO = 0
+    dMolFractionOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    if (iPhaseSystem <= 0 .OR. iPhaseSystem > nSolnPhasesSys .OR. iSpeciesPhase <= 0 .OR. &
+        iSpeciesPhase > nSpeciesPhase(iPhaseSystem) - nSpeciesPhase(iPhaseSystem - 1)) then
+        INFO = 2
+        return
+    end if
+
+    do i = 1, nElements
+        if (iAssemblage(i) < 0) then
+            if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                iActualPhase = -iAssemblage(i)
+                iActualSpecies = nSpeciesPhase(iActualPhase - 1) + iSpeciesPhase
+                dMolFractionOut = dMolFraction(iActualSpecies)
+                return
+            end if
+        end if
+    end do
+
+    INFO = 1
+
+end subroutine GetOutputMolSpeciesPhaseByIndexISO
+
+subroutine GetElementMolesInPhaseByIndexISO(iElementSystem, iPhaseSystem, dMolesOut, INFO) &
+    bind(C, name="TCAPI_getElementMolesInPhaseByIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolesPhase, dMolesSpecies, dStoichSpecies, &
+                            iAssemblage, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iElementSystem, iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dMolesOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iActualPhase, iTarget, j
+
+    INFO = 0
+    dMolesOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iElementSystem <= 0 .OR. iElementSystem > nElements) then
+        INFO = 1
+        return
+    end if
+    if (iPhaseSystem <= 0) then
+        INFO = 2
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    iActualPhase = -iAssemblage(i)
+                    do j = nSpeciesPhase(iActualPhase - 1) + 1, nSpeciesPhase(iActualPhase)
+                        dMolesOut = dMolesOut + dMolesSpecies(j) * dStoichSpecies(j, iElementSystem)
+                    end do
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                dMolesOut = dMolesPhase(i) * dStoichSpecies(iTarget, iElementSystem)
+                return
+            end if
+        end do
+    end if
+
+    INFO = 2
+
+end subroutine GetElementMolesInPhaseByIndexISO
+
 subroutine GetOutputSiteFractionISO(cSolnOut, lcSolnOut, iSublatticeOut, iConstituentOut, dSiteFractionOut, INFO) &
     bind(C, name="TCAPI_getOutputSiteFraction")
 
@@ -955,11 +1056,137 @@ subroutine GetPhaseIndexISO(cPhaseName, lcPhaseName, iIndexOut, INFO) &
 
     call c_f_pointer(cptr=c_loc(cPhaseName), fptr=fPhaseName)
 
-    call GetPhaseIndex(cPhaseName, lcPhaseName, iIndexOut, INFO)
+    call GetPhaseIndex(fPhaseName, lcPhaseName, iIndexOut, INFO)
 
     return
 
 end subroutine GetPhaseIndexISO
+
+subroutine GetPhaseIndexBySystemIndexISO(iPhaseSystem, iIndexOut, INFO) &
+    bind(C, name="TCAPI_getPhaseIndexBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, iAssemblage, nElements, nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    integer(C_INT), intent(out) :: iIndexOut, INFO
+    integer(C_INT)              :: i, iTarget
+
+    INFO = 0
+    iIndexOut = 0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    if (iPhaseSystem <= 0) then
+        INFO = 1
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    iIndexOut = i
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                iIndexOut = i
+                return
+            end if
+        end do
+    end if
+
+end subroutine GetPhaseIndexBySystemIndexISO
+
+subroutine GetPhaseMolesBySystemIndexISO(iPhaseSystem, dMolesOut, INFO) &
+    bind(C, name="TCAPI_getPhaseMolesBySystemIndex")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: cSolnPhaseName, dMolesPhase, iAssemblage, nElements, &
+                            nSolnPhasesSys, nSpeciesPhase
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iPhaseSystem
+    real(C_DOUBLE), intent(out) :: dMolesOut
+    integer(C_INT), intent(out) :: INFO
+    integer(C_INT)              :: i, iTarget
+
+    INFO = 0
+    dMolesOut = 0D0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+    if (iPhaseSystem <= 0) then
+        INFO = 1
+        return
+    end if
+
+    if (iPhaseSystem <= nSolnPhasesSys) then
+        do i = 1, nElements
+            if (iAssemblage(i) < 0) then
+                if (cSolnPhaseName(-iAssemblage(i)) == cSolnPhaseName(iPhaseSystem)) then
+                    dMolesOut = dMolesPhase(i)
+                    return
+                end if
+            end if
+        end do
+    else
+        iTarget = MAXVAL(nSpeciesPhase) + iPhaseSystem - nSolnPhasesSys
+        do i = 1, nElements
+            if (iAssemblage(i) == iTarget) then
+                dMolesOut = dMolesPhase(i)
+                return
+            end if
+        end do
+    end if
+
+end subroutine GetPhaseMolesBySystemIndexISO
+
+subroutine GetElementIndexByAtomicNumberISO(iAtomicNumber, iIndexOut, INFO) &
+    bind(C, name="TCAPI_getElementIndexByAtomicNumber")
+
+    USE,INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: iElementSystem
+    USE ModuleThermoIO, ONLY: INFOThermo
+
+    implicit none
+
+    integer(C_INT), intent(in)  :: iAtomicNumber
+    integer(C_INT), intent(out) :: iIndexOut, INFO
+    integer(C_INT)              :: i
+
+    INFO = 0
+    iIndexOut = 0
+
+    if (INFOThermo /= 0) then
+        INFO = -1
+        return
+    end if
+
+    do i = 1, SIZE(iElementSystem)
+        if (iElementSystem(i) /= 0) iIndexOut = iIndexOut + 1
+        if (iElementSystem(i) == iAtomicNumber) return
+    end do
+
+    iIndexOut = 0
+    INFO = 1
+
+end subroutine GetElementIndexByAtomicNumberISO
 
 subroutine GetPureConPhaseMolISO(cPureConOut, lcPureConOut, dPureConMolOut, INFO) &
     bind(C, name="TCAPI_getPureConPhaseMol")

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -17,6 +17,57 @@ subroutine SetThermoFileNameISO(cFileName, lcFileName) &
 
 end subroutine SetThermoFileNameISO
 
+subroutine ClearPhaseSelectionISO() &
+    bind(C, name="TCAPI_clearPhaseSelection")
+
+    USE ModuleThermoIO, ONLY: nPhasesExcluded, nPhasesExcludedExcept, &
+                              cPhasesExcluded, cPhasesExcludedExcept
+
+    implicit none
+
+    nPhasesExcluded = 0
+    nPhasesExcludedExcept = 0
+    cPhasesExcluded = ''
+    cPhasesExcludedExcept = ''
+
+end subroutine ClearPhaseSelectionISO
+
+subroutine AddPhaseSelectionISO(cPhase, lcPhase, lInclude, iInfo) &
+    bind(C, name="TCAPI_addPhaseSelection")
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermoIO, ONLY: nPhasesExcluded, nPhasesExcludedExcept, &
+                              cPhasesExcluded, cPhasesExcludedExcept
+
+    implicit none
+
+    character(kind=c_char,len=1), target, intent(in) :: cPhase(*)
+    integer(c_size_t), intent(in), value :: lcPhase
+    logical(c_bool), intent(in) :: lInclude
+    integer(c_int), intent(out) :: iInfo
+    character(kind=c_char,len=lcPhase), pointer :: fPhase
+
+    iInfo = 0
+    if (lcPhase == 0 .OR. lcPhase > len(cPhasesExcluded(1))) then
+        iInfo = 1
+        return
+    else if ((lInclude .AND. nPhasesExcludedExcept >= size(cPhasesExcludedExcept)) .OR. &
+             (.NOT. lInclude .AND. nPhasesExcluded >= size(cPhasesExcluded))) then
+        iInfo = 2
+        return
+    end if
+
+    call c_f_pointer(cptr=c_loc(cPhase), fptr=fPhase)
+    if (lInclude) then
+        nPhasesExcludedExcept = nPhasesExcludedExcept + 1
+        cPhasesExcludedExcept(nPhasesExcludedExcept) = fPhase
+    else
+        nPhasesExcluded = nPhasesExcluded + 1
+        cPhasesExcluded(nPhasesExcluded) = fPhase
+    end if
+
+end subroutine AddPhaseSelectionISO
+
 subroutine SetUnitTemperatureISO(cUnitTemperature, lcUnitTemperature) &
     bind(C, name="TCAPI_setUnitTemperature")
 

--- a/src/api/CouplingUtilitiesISO_C.f90
+++ b/src/api/CouplingUtilitiesISO_C.f90
@@ -1704,3 +1704,147 @@ subroutine SetFuzzyStoichISO(lFuzzyStoichIn) &
 
     return
   end subroutine SetMassBalanceToleranceISO
+
+subroutine GetNumberSublatticesISO(iPhase, iCount, iInfo) &
+    bind(C, name="TCAPI_getNumberSublattices")
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: nSolnPhasesSys, iPhaseSublattice, nSublatticePhase
+
+    implicit none
+
+    integer(c_int), intent(in) :: iPhase
+    integer(c_int), intent(out) :: iCount, iInfo
+    integer :: iSublatticePhase
+
+    iCount = 0
+    iInfo = 0
+    if (iPhase < 1 .OR. iPhase > nSolnPhasesSys) then
+        iInfo = 1
+        return
+    end if
+
+    iSublatticePhase = iPhaseSublattice(iPhase)
+    if (iSublatticePhase < 1) then
+        iInfo = 2
+        return
+    end if
+    iCount = nSublatticePhase(iSublatticePhase)
+
+end subroutine GetNumberSublatticesISO
+
+subroutine GetNumberConstituentsISO(iPhase, iSublattice, iCount, iInfo) &
+    bind(C, name="TCAPI_getNumberConstituents")
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: nSolnPhasesSys, iPhaseSublattice, nSublatticePhase, &
+                            nConstituentSublattice
+
+    implicit none
+
+    integer(c_int), intent(in) :: iPhase, iSublattice
+    integer(c_int), intent(out) :: iCount, iInfo
+    integer :: iSublatticePhase
+
+    iCount = 0
+    iInfo = 0
+    if (iPhase < 1 .OR. iPhase > nSolnPhasesSys) then
+        iInfo = 1
+        return
+    end if
+    iSublatticePhase = iPhaseSublattice(iPhase)
+    if (iSublatticePhase < 1 .OR. iSublattice < 1 .OR. &
+        iSublattice > nSublatticePhase(iSublatticePhase)) then
+        iInfo = 2
+        return
+    end if
+    iCount = nConstituentSublattice(iSublatticePhase, iSublattice)
+
+end subroutine GetNumberConstituentsISO
+
+function GetConstituentNameAtIndexISO(iPhase, iSublattice, iConstituent, iLength, iInfo) &
+    bind(C, name="TCAPI_getConstituentNameAtIndex")
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: nSolnPhasesSys, iPhaseSublattice, nSublatticePhase, &
+                            nConstituentSublattice, cConstituentNameSUB
+
+    implicit none
+
+    integer(c_int), intent(in) :: iPhase, iSublattice, iConstituent
+    integer(c_int), intent(out) :: iLength, iInfo
+    integer :: i, iSublatticePhase
+    character(kind=c_char), dimension(8), save, target :: cName
+    type(c_ptr) :: GetConstituentNameAtIndexISO
+
+    iLength = 0
+    iInfo = 0
+    GetConstituentNameAtIndexISO = c_null_ptr
+    if (iPhase < 1 .OR. iPhase > nSolnPhasesSys) then
+        iInfo = 1
+        return
+    end if
+    iSublatticePhase = iPhaseSublattice(iPhase)
+    if (iSublatticePhase < 1 .OR. iSublattice < 1 .OR. &
+        iSublattice > nSublatticePhase(iSublatticePhase)) then
+        iInfo = 2
+        return
+    else if (iConstituent < 1 .OR. &
+             iConstituent > nConstituentSublattice(iSublatticePhase, iSublattice)) then
+        iInfo = 3
+        return
+    end if
+
+    iLength = len_trim(cConstituentNameSUB(iSublatticePhase, iSublattice, iConstituent))
+    cName = c_null_char
+    do i = 1, iLength
+        cName(i) = cConstituentNameSUB(iSublatticePhase, iSublattice, iConstituent)(i:i)
+    end do
+    GetConstituentNameAtIndexISO = c_loc(cName(1))
+
+end function GetConstituentNameAtIndexISO
+
+subroutine GetConstituentFractionByIndexISO(iPhase, iSublattice, iConstituent, dValue, iInfo) &
+    bind(C, name="TCAPI_getConstituentFractionByIndex")
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo, ONLY: nSolnPhasesSys, cSolnPhaseName, cSolnPhaseType, iPhaseSublattice, &
+                            nSublatticePhase, nConstituentSublattice, cConstituentNameSUB
+
+    implicit none
+
+    integer(c_int), intent(in) :: iPhase, iSublattice, iConstituent
+    real(c_double), intent(out) :: dValue
+    integer(c_int), intent(out) :: iInfo
+    integer :: iSublatticePhase
+    integer(c_size_t) :: iPhaseNameLength
+
+    dValue = 0D0
+    iInfo = 0
+    if (iPhase < 1 .OR. iPhase > nSolnPhasesSys) then
+        iInfo = 1
+        return
+    end if
+    iSublatticePhase = iPhaseSublattice(iPhase)
+    if (iSublatticePhase < 1 .OR. iSublattice < 1 .OR. &
+        iSublattice > nSublatticePhase(iSublatticePhase)) then
+        iInfo = 2
+        return
+    else if (iConstituent < 1 .OR. &
+             iConstituent > nConstituentSublattice(iSublatticePhase, iSublattice)) then
+        iInfo = 3
+        return
+    end if
+
+    if (cSolnPhaseType(iPhase) == 'SUBL' .OR. cSolnPhaseType(iPhase) == 'SUBLM') then
+        iPhaseNameLength = len_trim(cSolnPhaseName(iPhase))
+        call GetOutputSiteFraction(cSolnPhaseName(iPhase), iPhaseNameLength, &
+                                   iSublattice, iConstituent, dValue, iInfo)
+    else if (cSolnPhaseType(iPhase) == 'SUBG' .OR. cSolnPhaseType(iPhase) == 'SUBQ') then
+        call GetMqmqaConstituentFraction(cSolnPhaseName(iPhase), iSublattice, &
+            cConstituentNameSUB(iSublatticePhase, iSublattice, iConstituent), dValue, iInfo)
+    else
+        iInfo = 4
+    end if
+
+end subroutine GetConstituentFractionByIndexISO

--- a/src/api/MQMQAFunctions.f90
+++ b/src/api/MQMQAFunctions.f90
@@ -304,7 +304,7 @@ subroutine GetMqmqaConstituentFraction(cPhase, iSublattice, cConstituent, dConst
         else if (iSublattice == 2) then
             ! Anions:
             do i = 1, nSub
-                j = i + nConstituentSublattice(iSPI,iSublattice)
+                j = i + nConstituentSublattice(iSPI,1)
                 do k = 1, nPairsSRO(iSPI,2)
                     l = iFirst + k - 1
                     dZx = dCoordinationNumber(iSPI,k,3)

--- a/test/daily/TestThermo91.F90
+++ b/test/daily/TestThermo91.F90
@@ -1,0 +1,149 @@
+!> \file TestThermo91.F90
+!> \brief Indexed thermodynamic result API checks.
+
+program TestThermo91
+
+    USE, INTRINSIC :: ISO_C_BINDING
+    USE ModuleThermo
+    USE ModuleThermoIO
+
+    implicit none
+
+    interface
+        subroutine GetSpeciesPotential(iPhase, iSpecies, dPotential, INFO) &
+            bind(C, name="TCAPI_getSpeciesChemicalPotentialByIndex")
+            import C_DOUBLE, C_INT
+            integer(C_INT), intent(in)  :: iPhase, iSpecies
+            real(C_DOUBLE), intent(out) :: dPotential
+            integer(C_INT), intent(out) :: INFO
+        end subroutine GetSpeciesPotential
+
+        subroutine GetEndmemberPotential(iPhase, iEndmember, dPotential, INFO) &
+            bind(C, name="TCAPI_getMqmqaEndmemberStoichiometricPotentialByIndex")
+            import C_DOUBLE, C_INT
+            integer(C_INT), intent(in)  :: iPhase, iEndmember
+            real(C_DOUBLE), intent(out) :: dPotential
+            integer(C_INT), intent(out) :: INFO
+        end subroutine GetEndmemberPotential
+
+        subroutine GetPhaseGibbsEnergy(iPhase, dTotal, dMolar, INFO) &
+            bind(C, name="TCAPI_getPhaseGibbsEnergyBySystemIndex")
+            import C_DOUBLE, C_INT
+            integer(C_INT), intent(in)  :: iPhase
+            real(C_DOUBLE), intent(out) :: dTotal, dMolar
+            integer(C_INT), intent(out) :: INFO
+        end subroutine GetPhaseGibbsEnergy
+
+        subroutine GetPhaseDrivingForce(iPhase, dDrivingForce, INFO) &
+            bind(C, name="TCAPI_getPhaseDrivingForceBySystemIndex")
+            import C_DOUBLE, C_INT
+            integer(C_INT), intent(in)  :: iPhase
+            real(C_DOUBLE), intent(out) :: dDrivingForce
+            integer(C_INT), intent(out) :: INFO
+        end subroutine GetPhaseDrivingForce
+
+        subroutine GetSystemGibbsEnergy(dGibbsEnergy, INFO) bind(C, name="TCAPI_getSystemGibbsEnergy")
+            import C_DOUBLE, C_INT
+            real(C_DOUBLE), intent(out) :: dGibbsEnergy
+            integer(C_INT), intent(out) :: INFO
+        end subroutine GetSystemGibbsEnergy
+    end interface
+
+    integer(C_INT) :: i, iFirst, iLast, iSpeciesLocal, iTargetPhase, iTargetSpecies, iSublattice, INFO
+    real(C_DOUBLE) :: dActual, dAtomSum, dExpected, dFractionSum, dMolar, dPhaseMoles
+    real(C_DOUBLE) :: dReferencePotential, dResidual, dTotal
+    logical        :: lPass
+
+    cInputUnitTemperature = 'K'
+    cInputUnitPressure    = 'atm'
+    cInputUnitMass        = 'moles'
+    cThermoFileName       = DATA_DIRECTORY // 'FeTiVO.dat'
+
+    dPressure       = 1D0
+    dTemperature    = 2000D0
+    dElementMass    = 0D0
+    dElementMass(8) = 2D0
+    dElementMass(22) = 0.5D0
+    dElementMass(23) = 0.5D0
+    dElementMass(26) = 0.5D0
+
+    call ParseCSDataFile(cThermoFileName)
+    call Thermochimica
+
+    lPass = INFOThermo == 0
+    iTargetPhase = 0
+    do i = 1, nSolnPhasesSys
+        if (cSolnPhaseName(i) == 'SlagBsoln') iTargetPhase = i
+    end do
+    lPass = lPass .AND. iTargetPhase > 0
+
+    call GetSystemGibbsEnergy(dActual, INFO)
+    lPass = lPass .AND. INFO == 0 .AND. Close(dActual, dGibbsEnergySys)
+
+    iTargetSpecies = 1
+    call GetSpeciesPotential(iTargetPhase, iTargetSpecies, dActual, INFO)
+    dExpected = dChemicalPotential(nSpeciesPhase(iTargetPhase - 1) + iTargetSpecies) * &
+                dIdealConstant * dTemperature
+    lPass = lPass .AND. INFO == 0 .AND. Close(dActual, dExpected)
+
+    iSublattice = iPhaseSublattice(iTargetPhase)
+    call GetEndmemberPotential(iTargetPhase, iTargetSpecies, dActual, INFO)
+    dExpected = SUM(dElementPotential(1:nElements) * &
+                    dStoichPairs(iSublattice, iTargetSpecies, 1:nElements))
+    dExpected = dExpected * dIdealConstant * dTemperature
+    lPass = lPass .AND. INFO == 0 .AND. Close(dActual, dExpected)
+
+    iFirst = nSpeciesPhase(iTargetPhase - 1) + 1
+    iLast = nSpeciesPhase(iTargetPhase)
+    dFractionSum = SUM(dMolFraction(iFirst:iLast))
+    dExpected = SUM(dChemicalPotential(iFirst:iLast) * dMolFraction(iFirst:iLast)) / dFractionSum
+    dExpected = dExpected * dIdealConstant * dTemperature
+
+    dPhaseMoles = 0D0
+    do i = 1, nElements
+        if (iAssemblage(i) == -iTargetPhase) dPhaseMoles = dMolesPhase(i)
+    end do
+    call GetPhaseGibbsEnergy(iTargetPhase, dTotal, dMolar, INFO)
+    lPass = lPass .AND. INFO == 0 .AND. Close(dMolar, dExpected)
+    lPass = lPass .AND. Close(dTotal, dExpected * dPhaseMoles)
+
+    dAtomSum = 0D0
+    dResidual = 0D0
+    do iSpeciesLocal = iFirst, iLast
+        if (dMolFraction(iSpeciesLocal) > 0D0) then
+            dReferencePotential = SUM(dElementPotential(1:nElements) * &
+                                      dStoichSpecies(iSpeciesLocal, 1:nElements))
+            dResidual = dResidual + dMolFraction(iSpeciesLocal) * &
+                        (dChemicalPotential(iSpeciesLocal) - dReferencePotential)
+            dAtomSum = dAtomSum + dMolFraction(iSpeciesLocal) * dSpeciesTotalAtoms(iSpeciesLocal)
+        end if
+    end do
+    dExpected = dResidual / dAtomSum * dIdealConstant * dTemperature
+    call GetPhaseDrivingForce(iTargetPhase, dActual, INFO)
+    lPass = lPass .AND. INFO == 0 .AND. Close(dActual, dExpected)
+
+    i = 0
+    call GetPhaseGibbsEnergy(i, dTotal, dMolar, INFO)
+    lPass = lPass .AND. INFO == 2
+
+    if (lPass) then
+        print *, 'TestThermo91: PASS'
+        call ResetThermoAll
+        call EXIT(0)
+    else
+        print *, 'TestThermo91: FAIL <---'
+        call ResetThermoAll
+        call EXIT(1)
+    end if
+
+contains
+
+    logical function Close(dLeft, dRight)
+        real(C_DOUBLE), intent(in) :: dLeft, dRight
+        real(C_DOUBLE)             :: dScale
+
+        dScale = MAX(1D0, ABS(dLeft), ABS(dRight))
+        Close = ABS(dLeft - dRight) <= 1D-12 * dScale
+    end function Close
+
+end program TestThermo91


### PR DESCRIPTION
## Summary

- add indexed metadata and result-query APIs for phases, species, elements, thermodynamic components, and constituents
- add phase inclusion and exclusion APIs for constrained equilibrium calculations
- expose phase and system Gibbs energies, phase driving forces, species chemical potentials, and constituent fractions through the C and C++ interfaces
- correct MQMQA anion constituent indexing used by the new constituent-fraction query

## Motivation

MOOSE currently resolves names and repeatedly queries metadata while processing every thermodynamic state. These APIs allow the integration to validate selections once during setup and use stable integer handles in the solve loop. Phase selection also enables constrained and metastable calculations needed for phase-field coupling.

## User and developer impact

Existing string-based interfaces remain available. Coupled applications can opt into the indexed APIs for lower lookup overhead and use the typed result queries without accessing Thermochimica's internal Fortran state.

## Validation

- built Thermochimica through the MOOSE Chemical Reactions module
- compared indexed queries with the existing string-based results
- exercised phase inclusion and exclusion in exact equilibrium calculations
- exercised constituent metadata and fractions for MQM and conventional sublattice phases
- ran the corresponding MOOSE tests with batch sizes 1 and 32 and with one and four threads
